### PR TITLE
Fix type assignments in example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# pyenv
+.python-version
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/

--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ Code examples can be found in the `test_parser.py` file.
 
 ### Code example
 
-    funders = {sender: address, value: wei_value}[num]
-    nextFunderIndex = num
-    beneficiary = address
-    deadline = timestamp
-    goal = wei_value
-    refundIndex = num
-    timelimit = timedelta
+    funders:{sender: address, value: wei_value}[num]
+    nextFunderIndex:num
+    beneficiary:address
+    deadline:timestamp
+    goal:wei_value
+    refundIndex:num
+    timelimit:timedelta
     
     # Setup global variables
     def __init__(_beneficiary: address, _goal: wei_value, _timelimit: timedelta):

--- a/examples/crowdfund.vy
+++ b/examples/crowdfund.vy
@@ -1,0 +1,38 @@
+funders:{sender: address, value: wei_value}[num]
+nextFunderIndex:num
+beneficiary:address
+deadline:timestamp
+goal:wei_value
+refundIndex:num
+timelimit:timedelta
+
+# Setup global variables
+def __init__(_beneficiary: address, _goal: wei_value, _timelimit: timedelta):
+    self.beneficiary = _beneficiary
+    self.deadline = block.timestamp + _timelimit
+    self.timelimit = _timelimit
+    self.goal = _goal
+
+# Participate in this crowdfunding campaign
+def participate():
+    assert block.timestamp < self.deadline
+    nfi = self.nextFunderIndex
+    self.funders[nfi] = {sender: msg.sender, value: msg.value}
+    self.nextFunderIndex = nfi + 1
+
+# Enough money was raised! Send funds to the beneficiary
+def finalize():
+    assert block.timestamp >= self.deadline and self.balance >= self.goal
+    selfdestruct(self.beneficiary)
+
+# Not enough money was raised! Refund everyone (max 30 people at a time
+# to avoid gas limit issues)
+def refund():
+    ind = self.refundIndex
+    for i in range(ind, ind + 30):
+        if i >= self.nextFunderIndex:
+            self.refundIndex = self.nextFunderIndex
+            return
+        send(self.funders[i].sender, self.funders[i].value)
+        self.funders[i] = None
+    self.refundIndex = ind + 30

--- a/viper
+++ b/viper
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from compiler_plugin import Compiler
+import argparse
+
+compiler = Compiler()
+parser = argparse.ArgumentParser()
+parser.add_argument("input")
+args = parser.parse_args()
+
+if __name__ == '__main__':
+    with open(args.input) as fh:
+        code = fh.read()
+        print(compiler.compile(code).hex())


### PR DESCRIPTION
- Global type assignments were old in the example. 
- Added a .gitignore as I saw `__pycache__` dir generated
- a small cli tool called ./viper 
- examples dir to populate, in spirit of Serpent repo. 

What should viper file extension be? I chose *.vy but maybe *.py is enough