### PR TITLE
Change `serpent` to `ethereum-serpent`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=[
         'ethereum == 1.3.7',
-        'serpent',
+        'ethereum-serpent',
         'nose',
     ],
     scripts=['bin/viper']


### PR DESCRIPTION
`serpent` installs https://pypi.python.org/pypi/serpent/1.19 . 

Instead, I think it should be `ethereum-serpent`

