### PR TITLE
Fix make installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 init:
-	pip install -r requirements.txt
+	python setup.py install
 
 test:
 	nosetests tests


### PR DESCRIPTION
This PR is in response to issue #276 and allows users to run `python setup.py install` with `make`