### PR TITLE
`send` throws on failure

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+import pytest
 from .setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas
 
 def test_null_code():
@@ -227,6 +228,22 @@ def refund():
 
     print('Passed escrow test with initializer')
     check_gas(arbitration_code_with_init, function='finalize')
+
+def test_send():
+    send_test = """
+
+def foo():
+    send(msg.sender, self.balance+1)
+
+def fop():
+    send(msg.sender, 10)
+    """
+    c = s.contract(send_test, language='viper', value=10)
+    with pytest.raises(t.TransactionFailed):
+        c.foo()
+    c.fop()
+    with pytest.raises(t.TransactionFailed):
+        c.fop()
 
 def test_decimal_test():
     decimal_test = """

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -425,7 +425,7 @@ def send(expr, args, kwargs, context):
     if context.is_constant:
         raise ConstancyViolationException("Cannot send ether inside a constant function!", expr)
     enforce_units(value.typ, expr.args[1], BaseType('num', {'wei': 1}))
-    return LLLnode.from_list(['pop', ['call', 0, to, value, 0, 0, 0, 0]], typ=None, pos=getpos(expr))
+    return LLLnode.from_list(['assert', ['call', 0, to, value, 0, 0, 0, 0]], typ=None, pos=getpos(expr))
 
 
 @signature('address')


### PR DESCRIPTION
This PR is in response to issue #310.  This PR changes `send` so that it throws on failure and tests the added functionality.  I tried to be as minimalistic as possible.