### PR TITLE
Failing test case for debugging constant inherited arguments

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -156,6 +156,33 @@ def foo() -> num:
     print('Passed basic state accessor test')
 
 
+def test_use_constant_function():
+    code="""
+bal: num[address]
+
+def __init__():
+    self.bal[msg.sender] = 1
+
+@constant
+def get_my_bal() -> num:
+    return self.bal[msg.sender]
+
+def foo():
+    assert self.bal[msg.sender] > 0
+    self.bal[msg.sender] += 1
+
+def bar():
+    assert self.get_my_bal() > 0
+    self.bal[msg.sender] += 1
+    """
+    
+    c = s.contract(code, language='viper')
+    assert c.get_my_bal() == 1
+    c.foo() # equivalent code to bar()
+    c.bar() # This transaction should estimate less gas than foo(), but take the same amt
+    assert c.get_my_bal() == 3
+    check_gas(code, num_txs=4)
+
 def test_arbitration_code():
     arbitration_code = """
 buyer: address

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -156,32 +156,26 @@ def foo() -> num:
     print('Passed basic state accessor test')
 
 
-def test_use_constant_function():
+def test_reuse_function():
     code="""
 bal: num[address]
 
 def __init__():
     self.bal[msg.sender] = 1
 
-@constant
-def get_my_bal() -> num:
+def my_bal() -> num:
     return self.bal[msg.sender]
 
-def foo():
-    assert self.bal[msg.sender] > 0
-    self.bal[msg.sender] += 1
-
 def bar():
-    assert self.get_my_bal() > 0
+    assert self.my_bal() > 0
     self.bal[msg.sender] += 1
     """
     
     c = s.contract(code, language='viper')
-    assert c.get_my_bal() == 1
-    c.foo() # equivalent code to bar()
-    c.bar() # This transaction should estimate less gas than foo(), but take the same amt
-    assert c.get_my_bal() == 3
-    check_gas(code, num_txs=4)
+    assert c.my_bal() == 1
+    c.bar()
+    assert c.my_bal() == 2
+    check_gas(code, num_txs=3)
 
 def test_arbitration_code():
     arbitration_code = """

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -163,6 +163,7 @@ bal: num[address]
 def __init__():
     self.bal[msg.sender] = 1
 
+@constant
 def my_bal() -> num:
     return self.bal[msg.sender]
 
@@ -171,11 +172,10 @@ def bar():
     self.bal[msg.sender] += 1
     """
     
-    c = s.contract(code, language='viper')
+    c = get_contract_with_gas_estimation(code)
     assert c.my_bal() == 1
     c.bar()
     assert c.my_bal() == 2
-    check_gas(code, num_txs=3)
 
 def test_arbitration_code():
     arbitration_code = """


### PR DESCRIPTION
See #315

Looking for help resolving this problem as the compiler should be passing through all the inherited arguments (e.g. `msg.sender`) in the context call to a function from within another function.