### PR TITLE
Fix test path

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,4 +11,6 @@ test = pytest
 
 [tool:pytest]
 addopts = --cov-report term --cov-report html --cov=viper
-python_files = tests/test_*.py
+python_files = test_*.py
+testpaths = tests
+

--- a/tests/examples/voting/test_ballot.py
+++ b/tests/examples/voting/test_ballot.py
@@ -1,3 +1,5 @@
+import unittest
+
 from ethereum.tools import tester
 import ethereum.utils as utils
 import ethereum.abi as abi


### PR DESCRIPTION
### - What I did
I updated the test discovery option in `setup.cfg` so that pytest also looks into the subdirectories of `tests/`.

Additionally a small update to resolve an `ImportError` that was raised in one of the tests that wasn't being tested.

### - How I did it
Changed `setup.cfg`

### - How to verify it
If you run `python setup.py test` without these changes, and again with these changes, you will see more tests being run in the latter case.

### - Description for the changelog
N/A

### - Cute Animal Picture
![cute cat](https://i.pinimg.com/736x/f6/52/9a/f6529ac231ff06ee3401d806741e45cc--cute-cats-adorable-animals.jpg)
