### PR TITLE
Format the ABI output to be JSON.

### DIFF
--- a/bin/viper
+++ b/bin/viper
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3.6
+import argparse
+import json
 
 import viper
 from viper import compiler, optimizer
 from viper.parser import parse_to_lll
-import argparse
 
 parser = argparse.ArgumentParser(description='Viper {0} programming language for Ethereum'.format(viper.__version__))
 parser.add_argument('input_file', help='Viper sourcecode to compile')
-parser.add_argument('-f', help='Format to print', choices=['abi', 'bytecode', 'ir'], default='bytecode', dest='format')
+parser.add_argument('-f', help='Format to print', choices=['abi', 'json', 'bytecode', 'ir'], default='bytecode', dest='format')
 
 args = parser.parse_args()
 
@@ -16,7 +17,9 @@ if __name__ == '__main__':
         code = fh.read()
         if args.format == 'abi':
             print(compiler.mk_full_signature(code))
+        elif args.format == 'json':
+            print(json.dumps(compiler.mk_full_signature(code)))
         elif args.format == 'bytecode':
-            print('0x'+compiler.compile(code).hex())
+            print('0x' + compiler.compile(code).hex())
         elif args.format == 'ir':
             print(optimizer.optimize(parse_to_lll(code)))


### PR DESCRIPTION
### - What I did

- For easy copy-paste purposes, I found that I constantly had to convert the python ABI output from the command line, this just does a simple json.dumps to make it easier.
- Minor pep8 fixes in the same file.

### - How I did it

Inserted a json.dumps ;)

### - How to verify it

Run `./viper_bin.py examples/crowdfund.vy -f json` and check the output.

### - Description for the changelog

Use JSON ABI output instead of python output (-f abi).

### - Cute Animal Picture

![](http://4.bp.blogspot.com/-HTvSYzA-pO4/UgQb4Zh_u0I/AAAAAAAAEuI/XwhtogT_1tA/s1600/3+cute2.jpg)