### PR TITLE
Move readme to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Compatibility-breaking change log
     :maxdepth: 2
 
     installing-viper.rst
+    viper-in-depth.rst
     contributing.rst
     frequently-asked-questions.rst
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -1,0 +1,67 @@
+.. index:: contract, state variable, function, event, struct, enum, function;modifier
+
+.. _contract_structure:
+
+***********************
+Structure of a Contract
+***********************
+
+Contracts in Viper are contained within files, with each file being one smart-contract.  Files in Viper are similar to classes in object-oriented languages.
+Each file can contain declarations of :ref:`structure-state-variables`, :ref:`structure-functions`, and :ref:`structure-structs-types`.
+
+.. _structure-state-variables:
+
+State Variables
+===============
+
+State variables are values which are permanently stored in contract storage.
+
+::
+
+  storedData: num
+
+See the :ref:`types` section for valid state variable types and
+:ref:`visibility-and-getters` for possible choices for
+visibility.
+
+.. _structure-functions:
+
+Functions
+=========
+
+Functions are the executable units of code within a contract.
+
+::
+
+  @payable
+  function bid(): // Function
+    // ...
+  }
+
+:ref:`function-calls` can happen internally or externally
+and have different levels of visibility (:ref:`visibility-and-getters`)
+towards other contracts.
+
+
+
+.. _structure-structs-types:
+
+Structs Types
+=============
+
+Structs are custom defined types that can group several variables (see
+:ref:`structs` in types section).
+
+::
+
+    # Information about voters
+    voters: public({
+        # weight is accumulated by delegation
+        weight: num,
+        # if true, that person already voted
+        voted: bool,
+        # person delegated to
+        delegate: address,
+        # index of the voted proposal
+        vote: num
+    })

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -1,4 +1,4 @@
-.. index:: contract, state variable, function, event, struct, enum, function;modifier
+.. index:: contract, state variable, function;
 
 .. _contract_structure:
 
@@ -42,26 +42,3 @@ Functions are the executable units of code within a contract.
 and have different levels of visibility (:ref:`visibility-and-getters`)
 towards other contracts.
 
-
-
-.. _structure-structs-types:
-
-Structs Types
-=============
-
-Structs are custom defined types that can group several variables (see
-:ref:`structs` in types section).
-
-::
-
-    # Information about voters
-    voters: public({
-        # weight is accumulated by delegation
-        weight: num,
-        # if true, that person already voted
-        voted: bool,
-        # person delegated to
-        delegate: address,
-        # index of the voted proposal
-        vote: num
-    })

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -34,8 +34,7 @@ Operators:
 *  ``and`` (logical conjunction, "&&")
 *  ``or`` (logical disjunction, "||")
 *  ``==`` (equality)
-*  ``not ... == ... `` (inequality)
-*  ``!=`` (inequality)
+*  ``not ... == ... ``, ``!=`` (inequality)
 
 The operators ``or`` and ``and`` apply the common short-circuiting rules. This means that in the expression ``f(x) or g(y)``, if ``f(x)`` evaluates to ``true``, ``g(y)`` will not be evaluated even if it may have side-effects.
 
@@ -45,7 +44,7 @@ The operators ``or`` and ``and`` apply the common short-circuiting rules. This m
 Integers
 --------
 
-``num``:  a signed integer strictly between -2\*\*128 and 2\*\*128.
+``num``:  equivalent to``int128``, a signed integer strictly between -2\*\*127 and 2\*\*127-1.
 
 Operators:
 
@@ -55,21 +54,21 @@ Operators:
 
 Decimals
 --------
-``decimal``:  a decimal fixed point value with the integer component being a signed integer strictly between -2\*\*128 and 2\*\*128 and the fractional component being ten decimal places
+``decimal``:  a decimal fixed point value with the integer component represented as a ``num`` and the fractional component supporting up to ten decimal places.
 
 
 Time
 -----
-``timestamp``:  a timestamp value
+``timestamp``:  a timestamp value with a base unit of one second, represented as a ``num``.
 
-``timedelta``:  a number of seconds (note: two timedeltas can be added together, as can a timedelta and a timestamp, but not two timestamps)
+``timedelta``:  a number of seconds (note: two timedeltas can be added together, as can a timedelta and a timestamp, but not two timestamps), represented as a ``num``.
 
 
 Value
 ------
-``wei_value``:  an amount of wei
+``wei_value``:  an amount of `ether <http://ethdocs.org/en/latest/ether.html#denominations>`_ with a base unit of one wei, represented as a ``num``.
 
-``currency_value``:  an amount of currency
+``currency_value``:  represents an amount of currency and should be used to represent assets where ether is traded for value, represented as a ``num``.
 
 
 
@@ -78,7 +77,7 @@ Value
 Address
 -------
 
-``address``: Holds a 20 byte value (size of an Ethereum address).
+``address``: Holds an Ethereum address (20 byte value).
 
 
 .. _members-of-addresses:
@@ -108,15 +107,55 @@ Fixed-size byte arrays
 
 ``bytes32``: 32 bytes
 
-``type[length]``: finite list
+::
+
+    # Declaration
+    hash: bytes32
+
+    # Assignment
+    self.hash = _hash
 
 ``bytes <= maxlen``: a byte array with the given maximum length
 
+::
+
+    # Declaration
+    name: bytes <= 5
+
+    # Assignment
+    self.name = _name
+
+``type[length]``: finite list
+
+::
+
+    # Declaration
+    numbers: num[3]
+
+    # Assignment
+    self.numbers[0] = _num1
+
+
+.. index:: !structs
 
 Structs
 -------
 
-``{arg1:type, arg2:type...}``:  struct (can be accessed via struct.argname)
+Structs are custom defined types that can group several variables.  They can be accessed via ``struct.argname``.
+
+::
+
+    # Information about voters
+    voters: public({
+        # weight is accumulated by delegation
+        weight: num,
+        # if true, that person already voted
+        voted: bool,
+        # person delegated to
+        delegate: address,
+        # index of the voted proposal
+        vote: num
+    })
 
 
 .. index:: !mapping

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -1,0 +1,145 @@
+.. index:: type
+
+.. _types:
+
+*****
+Types
+*****
+
+Viper is a statically typed language, which means that the type of each
+variable (state and local) needs to be specified or at least known at
+compile-time. Viper provides several elementary types which can be combined
+to form complex types.
+
+In addition, types can interact with each other in expressions containing
+operators.
+
+Value Types
+===========
+
+The following types are also called value types because variables of these
+types will always be passed by value, i.e. they are always copied when they
+are used as function arguments or in assignments.
+
+.. index:: ! bool, ! true, ! false
+
+Booleans
+--------
+
+``bool``: The possible values are constants ``true`` and ``false``.
+
+Operators:
+
+*  ``not`` (logical negation)
+*  ``and`` (logical conjunction, "&&")
+*  ``or`` (logical disjunction, "||")
+*  ``==`` (equality)
+*  ``not ... == ... `` (inequality)
+*  ``!=`` (inequality)
+
+The operators ``or`` and ``and`` apply the common short-circuiting rules. This means that in the expression ``f(x) or g(y)``, if ``f(x)`` evaluates to ``true``, ``g(y)`` will not be evaluated even if it may have side-effects.
+
+.. index:: ! uint, ! int, ! integer
+
+
+Integers
+--------
+
+``num``:  a signed integer strictly between -2\*\*128 and 2\*\*128.
+
+Operators:
+
+* Comparisons: ``<=``, ``<``, ``==``, ``!=``, ``>=``, ``>`` (evaluate to ``bool``)
+* Arithmetic operators: ``+``, ``-``, unary ``-``, unary ``+``, ``*``, ``/``, ``%`` (remainder)
+
+
+Decimals
+--------
+``decimal``:  a decimal fixed point value with the integer component being a signed integer strictly between -2\*\*128 and 2\*\*128 and the fractional component being ten decimal places
+
+
+Time
+-----
+``timestamp``:  a timestamp value
+
+``timedelta``:  a number of seconds (note: two timedeltas can be added together, as can a timedelta and a timestamp, but not two timestamps)
+
+
+Value
+------
+``wei_value``:  an amount of wei
+
+``currency_value``:  an amount of currency
+
+
+
+.. _address:
+
+Address
+-------
+
+``address``: Holds a 20 byte value (size of an Ethereum address).
+
+
+.. _members-of-addresses:
+
+Members of Addresses
+^^^^^^^^^^^^^^^^^^^^
+
+* ``balance`` and ``send``
+
+It is possible to query the balance of an address using the property ``balance``
+and to send Ether (in units of wei) to an address using the ``send`` function:
+
+::
+
+    x: address
+
+    def foo(x: adress):
+        if (x.balance < 10 and self.balance >= 10):
+            x.send(10)
+
+
+.. index:: byte array, bytes32
+
+
+Fixed-size byte arrays
+----------------------
+
+``bytes32``: 32 bytes
+
+``type[length]``: finite list
+
+``bytes <= maxlen``: a byte array with the given maximum length
+
+
+Structs
+-------
+
+``{arg1:type, arg2:type...}``:  struct (can be accessed via struct.argname)
+
+
+.. index:: !mapping
+
+Mappings
+========
+
+Mapping types are declared as ``_ValueType[_KeyType]``.
+Here ``_KeyType`` can be almost any type except for mappings, a contract, or a struct.
+``_ValueType`` can actually be any type, including mappings.
+
+Mappings can be seen as `hash tables <https://en.wikipedia.org/wiki/Hash_table>`_ which are virtually initialized such that
+every possible key exists and is mapped to a value whose byte-representation is
+all zeros: a type's :ref:`default value <default-value>`. The similarity ends here, though: The key data is not actually stored
+in a mapping, only its ``keccak256`` hash used to look up the value.
+
+Because of this, mappings do not have a length or a concept of a key or value being "set".
+
+Mappings are only allowed as state variables.
+
+It is possible to mark mappings ``public`` and have Viper create a :ref:`getter <visibility-and-getters>`.
+The ``_KeyType`` will become a required parameter for the getter and it will
+return ``_ValueType``.
+
+.. note::
+    Mappings can only be accessed, not iterated over.

--- a/docs/viper-in-depth.rst
+++ b/docs/viper-in-depth.rst
@@ -1,0 +1,22 @@
+#################
+Viper in Depth
+#################
+
+This section should provide you with all you need to know about Viper.
+If something is missing here, please contact us on
+`Gitter <https://gitter.im/ethereum/viper>`_ or make a pull request on
+`Github <https://github.com/ethereum/viper/pulls>`_.
+
+.. toctree::
+   :maxdepth: 2
+
+   layout-of-source-files.rst
+   structure-of-a-contract.rst
+   types.rst
+   grammar.rst
+   units-and-global-variables.rst
+   control-structures.rst
+   contracts.rst
+   assembly.rst
+   miscellaneous.rst
+


### PR DESCRIPTION
### - What I did
Added `structure of contract` and `types` pages to the docs.

### - How I did it
I did it by looking at the Solidity docs for formatting and then added parts of the old readme file to the docs.

### - How to verify it
Clone down this branch and enter `make docs`

### - Description for the changelog

### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/30525737-fe72036c-9bd1-11e7-82f9-005e891b4e4b.png)

