### PR TITLE
Num256 with natural expressions.

### DIFF
--- a/tests/parser/types/numbers/test_num256.py
+++ b/tests/parser/types/numbers/test_num256.py
@@ -52,3 +52,52 @@ def _num256_le(x: num256, y: num256) -> bool:
     assert c._num256_lt(y, x) is True
 
     print("Passed num256 operation tests")
+
+
+def test_num_256_natural_operators():
+    num256_code = """
+def _num256_add(x: num256, y: num256) -> num256:
+    return x + y
+
+def _num256_sub(x: num256, y: num256) -> num256:
+    return x - y
+
+def _num256_mul(x: num256, y: num256) -> num256:
+    return x * y
+
+def _num256_div(x: num256, y: num256) -> num256:
+    return x / y
+
+def _num256_gt(x: num256, y: num256) -> bool:
+    return x > y
+
+def _num256_ge(x: num256, y: num256) -> bool:
+    return x >= y
+
+def _num256_lt(x: num256, y: num256) -> bool:
+    return x < y
+
+def _num256_le(x: num256, y: num256) -> bool:
+    return x <= y
+"""
+
+    c = get_contract_with_gas_estimation(num256_code)
+    x = 126416208461208640982146408124
+    y = 7128468721412412459
+
+    assert c._num256_add(x, y) == x + y
+    assert c._num256_sub(x, y) == x - y
+    assert c._num256_sub(y, x) == 2**256 + y - x
+    assert c._num256_mul(x, y) == x * y
+    assert c._num256_mul(2**128, 2**128) == 0
+    assert c._num256_div(x, y) == x // y
+    assert c._num256_div(y, x) == 0
+    assert c._num256_gt(x, y) is True
+    assert c._num256_ge(x, y) is True
+    assert c._num256_le(x, y) is False
+    assert c._num256_lt(x, y) is False
+    assert c._num256_gt(x, x) is False
+    assert c._num256_ge(x, x) is True
+    assert c._num256_le(x, x) is True
+    assert c._num256_lt(x, x) is False
+    assert c._num256_lt(y, x) is True

--- a/viper/types.py
+++ b/viper/types.py
@@ -337,7 +337,7 @@ def are_units_compatible(frm, to):
 
 # Is a type representing a number?
 def is_numeric_type(typ):
-    return isinstance(typ, BaseType) and typ.typ in ('num', 'decimal')
+    return isinstance(typ, BaseType) and typ.typ in ('num256', 'num', 'decimal')
 
 
 # Is a type representing some particular base type?


### PR DESCRIPTION
### - What I did

Added support for num256 to be evaluated without using builtin num256_xxx functions.

### - How I did it

- I started looking at basic evaluations off the following expressions:

```python
def _num256_sub(x: num256, y: num256) -> num256:
    return x - y
```

- And the compiler didn't understand num256 without the num256_xxx functions.
- Currently num256 -> decimal -> num operations are not handled yet but I felt this could be a seperate PR instead.

### - How to verify it

Check the test, one can also evaluate the LLL output with the following example (or similar):

```python
def multiply(x: num256, y: num256) -> num256:
    return x * y


def multiply_func(x: num256, y: num256) -> num256:
    return num256_mul(x, y)

```

### - Description for the changelog

Allows evaluating of basic arithmetic expressions using uint256 and uint256.

### - Cute Animal Picture

![](https://i.pinimg.com/736x/db/ba/1e/dbba1eaf15278838908a5938de317c3c--baby-bunnies-bunny-rabbits.jpg)
