### PR TITLE
Add exponents

### DIFF
--- a/tests/parser/types/numbers/test_num.py
+++ b/tests/parser/types/numbers/test_num.py
@@ -1,0 +1,18 @@
+import pytest
+from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
+    get_contract_with_gas_estimation, get_contract
+
+def test_exponents_with_nums():
+    exp_code = """
+def _num_exp(x: num, y: num) -> num:
+    return x**y
+    """
+
+    c = get_contract(exp_code)
+    assert c._num_exp(2,2) == 4
+    assert c._num_exp(2,3) == 8
+    assert c._num_exp(2,4) == 16
+    assert c._num_exp(3,2) == 9
+    assert c._num_exp(3,3) == 27
+    assert c._num_exp(72,19) == 194678249355036212415530357760196608
+

--- a/tests/parser/types/numbers/test_num.py
+++ b/tests/parser/types/numbers/test_num.py
@@ -14,5 +14,5 @@ def _num_exp(x: num, y: num) -> num:
     assert c._num_exp(2,4) == 16
     assert c._num_exp(3,2) == 9
     assert c._num_exp(3,3) == 27
-    assert c._num_exp(72,19) == 194678249355036212415530357760196608
+    assert c._num_exp(72,19) == 72**19
 

--- a/tests/parser/types/numbers/test_num256.py
+++ b/tests/parser/types/numbers/test_num256.py
@@ -63,4 +63,4 @@ def _num256_exp(x: num256, y: num256) -> num256:
     assert c._num256_exp(2, 3) == 8
     assert c._num256_exp(2**128, 2) == 0
     assert c._num256_exp(2**64, 2) == 2**128
-    assert c._num256_exp(7**23, 3) == 20500514515695490612229010908095867391439626248463723805607
+    assert c._num256_exp(7**23, 3) == 7**69

--- a/tests/parser/types/numbers/test_num256.py
+++ b/tests/parser/types/numbers/test_num256.py
@@ -52,3 +52,15 @@ def _num256_le(x: num256, y: num256) -> bool:
     assert c._num256_lt(y, x) is True
 
     print("Passed num256 operation tests")
+
+def test_num256_with_exponents():
+    exp_code = """
+def _num256_exp(x: num256, y: num256) -> num256:
+        return num256_exp(x,y)
+    """
+
+    c = get_contract(exp_code)
+    assert c._num256_exp(2, 3) == 8
+    assert c._num256_exp(2**128, 2) == 0
+    assert c._num256_exp(2**64, 2) == 2**128
+    assert c._num256_exp(7**23, 3) == 20500514515695490612229010908095867391439626248463723805607

--- a/tests/test_invalids.py
+++ b/tests/test_invalids.py
@@ -1120,6 +1120,11 @@ def baa():
 """)
 
 must_fail("""
+def baa() -> decimal:
+    return 2.0**2
+""", TypeMismatchException)
+
+must_fail("""
 def baa():
     x: bytes <= 50
     y: bytes <= 50
@@ -1166,6 +1171,11 @@ must_fail("""
 def foo(inp: num) -> bytes <= 3:
     return slice(inp, start=2, len=3)
 """, TypeMismatchException)
+
+must_fail("""
+def foo() -> num:
+    return block.fail
+""", Exception)
 
 must_fail("""
 def foo(inp: bytes <= 10) -> bytes <= 3:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,6 +4,15 @@ from .setup_transaction_tests import chain as s, tester as t, ethereum_utils as 
     curve_order, negative_G1
 
 
+def test_block_number():
+    block_number_code = """
+def block_number() -> num:
+    return block.number
+"""
+    c = get_contract(block_number_code)
+    c.block_number() == 2
+
+
 def test_send():
     send_test = """
 

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -674,6 +674,11 @@ def num256_div(expr, args, kwargs, context):
 
 
 @signature('num256', 'num256')
+def num256_exp(expr, args, kwargs, context):
+    return LLLnode.from_list(['exp', args[0], args[1]], typ=BaseType('num256'), pos=getpos(expr))
+
+
+@signature('num256', 'num256')
 def num256_mod(expr, args, kwargs, context):
     return LLLnode.from_list(['mod', args[0], args[1]], typ=BaseType('num256'), pos=getpos(expr))
 
@@ -809,6 +814,7 @@ dispatch_table = {
     'num256_sub': num256_sub,
     'num256_mul': num256_mul,
     'num256_div': num256_div,
+    'num256_exp': num256_exp,
     'num256_mod': num256_mod,
     'num256_addmod': num256_addmod,
     'num256_mulmod': num256_mulmod,

--- a/viper/parser.py
+++ b/viper/parser.py
@@ -616,6 +616,14 @@ def parse_expr(expr, context):
             elif ltyp == 'num' and rtyp == 'decimal':
                 o = LLLnode.from_list(['smod', ['mul', left, DECIMAL_DIVISOR], right],
                                       typ=BaseType('decimal', new_unit), pos=getpos(expr))
+        elif isinstance(expr.op, ast.Pow):
+            if left.typ.positional or right.typ.positional:
+                raise TypeMismatchException("Cannot use positional values as exponential arguments!", expr)
+            new_unit = combine_units(left.typ.unit, right.typ.unit)
+            if ltyp == rtyp == 'num':
+                o = LLLnode.from_list(['exp', left, right], typ=BaseType('num', new_unit), pos=getpos(expr))
+            else:
+                raise TypeMismatchException('Only whole number exponents are supported', expr)
         else:
             raise Exception("Unsupported binop: %r" % expr.op)
         if o.typ.typ == 'num':


### PR DESCRIPTION
### - What I did
Added support for num exponents (`num**num`) and num256 exponents (`num256_exp(num256,num256)`).  This pr is in response to issue #363.
### - How I did it
I did it by parsing for `**` and `num256` and then utilizing the exponent opcode (`exp`)).
### - How to verify it
Look at my pr (especially the tests)
### - Description for the changelog
Support integer exponents
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/30944064-a42aec46-a3b2-11e7-909f-54040966c2ed.png)

