### PR TITLE
Refactor parser parse_stmt method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license=license,
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=[
-        'ethereum>=2.0.4',
+        'ethereum==2.0.5',
         'bumpversion',
         'pytest-cov',
         'pytest-runner', # Must be after pytest-cov or it will not work

--- a/viper/compile_lll.py
+++ b/viper/compile_lll.py
@@ -1,4 +1,4 @@
-from .parser import LLLnode
+from viper.parser.parser import LLLnode
 from .opcodes import opcodes
 from .utils import FREE_VAR_SPACE
 

--- a/viper/compiler.py
+++ b/viper/compiler.py
@@ -1,4 +1,4 @@
-from . import parser
+from viper.parser import parser
 from . import compile_lll
 from . import optimizer
 

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -6,7 +6,7 @@ from .exceptions import (
     StructureException,
     TypeMismatchException,
 )
-from .parser_utils import (
+from viper.parser.parser_utils import (
     byte_array_to_num,
     LLLnode,
     get_length,
@@ -52,7 +52,7 @@ class Optional(object):
 
 
 def process_arg(index, arg, expected_arg_typelist, function_name, context):
-    from .parser import parse_expr, parse_value_expr
+    from viper.parser.parser import parse_expr, parse_value_expr
     if isinstance(expected_arg_typelist, Optional):
         expected_arg_typelist = expected_arg_typelist.typ
     if not isinstance(expected_arg_typelist, tuple):
@@ -239,7 +239,7 @@ def _len(expr, args, kwargs, context):
 
 
 def concat(expr, context):
-    from .parser import parse_expr, unwrap_location
+    from viper.parser.parser import parse_expr, unwrap_location
     args = [parse_expr(arg, context) for arg in expr.args]
     if len(args) < 2:
         raise StructureException("Concat expects at least two arguments", expr)
@@ -615,7 +615,7 @@ def _RLPlist(expr, args, kwargs, context):
 
 @signature('*', 'bytes')
 def raw_log(expr, args, kwargs, context):
-    from .parser import parse_value_expr
+    from viper.parser.parser import parse_value_expr
     if not isinstance(args[0], ast.List) or len(args[0].elts) > 4:
         raise StructureException("Expecting a list of 0-4 topics as first argument", args[0])
     topics = []

--- a/viper/optimizer.py
+++ b/viper/optimizer.py
@@ -1,4 +1,4 @@
-from .parser_utils import LLLnode
+from viper.parser.parser_utils import LLLnode
 from .utils import (
     ADDRSIZE_POS,
     DECIMAL_DIVISOR,

--- a/viper/parser.py
+++ b/viper/parser.py
@@ -950,189 +950,232 @@ def make_setter(left, right, location):
     else:
         raise Exception("Invalid type for setters")
 
+# Extracted parser functionality
+def parse_stmt_expr(stmt, context): 
+    return parse_stmt(stmt.value, context)
+
+
+def parse_stmt_pass(stmt, context):
+    return LLLnode.from_list('pass', typ=None, pos=getpos(stmt))
+
+
+def parse_stmt_ann_assign(stmt, context):
+    typ = parse_type(stmt.annotation, location='memory')
+    varname = stmt.target.id
+    pos = context.new_variable(varname, typ)
+    return LLLnode.from_list('pass', typ=None, pos=getpos(stmt))
+
+
+def parse_stmt_assign(stmt, context):
+# Assignment (eg. x[4] = y)
+    if len(stmt.targets) != 1:
+        raise StructureException("Assignment statement must have one target", stmt)
+    sub = parse_expr(stmt.value, context)
+    if isinstance(stmt.targets[0], ast.Name) and stmt.targets[0].id not in context.vars:
+        pos = context.new_variable(stmt.targets[0].id, set_default_units(sub.typ))
+        variable_loc = LLLnode.from_list(pos, typ=sub.typ, location='memory', pos=getpos(stmt), annotation=stmt.targets[0].id)
+        o = make_setter(variable_loc, sub, 'memory')
+    else:
+        target = parse_variable_location(stmt.targets[0], context)
+        if target.location == 'storage' and context.is_constant:
+            raise ConstancyViolationException("Cannot modify storage inside a constant function!", stmt.targets[0])
+        if not target.mutable:
+            raise ConstancyViolationException("Cannot modify function argument", stmt.targets[0])
+        o = make_setter(target, sub, target.location)
+    o.pos = getpos(stmt)
+    return o
+
+
+def parse_stmt_if(stmt, context):
+    if stmt.orelse:
+        add_on = [parse_body(stmt.orelse, context)]
+    else:
+        add_on = []
+    return LLLnode.from_list(['if',parse_value_expr(stmt.test, context),parse_body(stmt.body, context)] + add_on, typ=None, pos=getpos(stmt))
+
+
+def parse_stmt_call(stmt, context):
+    if isinstance(stmt.func, ast.Name) and stmt.func.id in stmt_dispatch_table:
+            return stmt_dispatch_table[stmt.func.id](stmt, context)
+    elif isinstance(stmt.func, ast.Attribute) and isinstance(stmt.func.value, ast.Name) and stmt.func.value.id == "self":
+        if stmt.func.attr not in context.sigs['self']:
+            raise VariableDeclarationException("Function not declared yet (reminder: functions cannot "
+                                                "call functions later in code than themselves): %s" % stmt.func.attr)
+        inargs, inargsize = pack_arguments(context.sigs['self'][stmt.func.attr],
+                                            [parse_expr(arg, context) for arg in stmt.args],
+                                            context)
+        return LLLnode.from_list(['assert', ['call', ['gas'], ['address'], 0, inargs, inargsize, 0, 0]],
+                                    typ=None, pos=getpos(stmt))
+    elif isinstance(stmt.func, ast.Attribute) and isinstance(stmt.func.value, ast.Call):
+        return external_contract_call_stmt(stmt, context)
+    elif isinstance(stmt.func, ast.Attribute) and stmt.func.value.id == 'log':
+        if stmt.func.attr not in context.sigs['self']:
+            raise VariableDeclarationException("Event not declared yet: %s" % stmt.func.attr)
+        event = context.sigs['self'][stmt.func.attr]
+        topics, stored_topics, event, data = pack_logging_topics(event, stmt.args, context)
+        inargs, inargsize, inarg_start = pack_logging_data(event, data, context)
+        return LLLnode.from_list(['seq', inargs, stored_topics, ["log" + str(len(topics)), inarg_start, inargsize] + topics], typ=None, pos=getpos(stmt))
+    else:
+        raise StructureException("Unsupported operator: %r" % ast.dump(stmt), stmt)
+
+
+def parse_stmt_assert(stmt, context):
+    return LLLnode.from_list(['assert', parse_value_expr(stmt.test, context)], typ=None, pos=getpos(stmt))
+
+
+def parse_stmt_for(stmt, context):
+    if not isinstance(stmt.iter, ast.Call) or \
+        not isinstance(stmt.iter.func, ast.Name) or \
+        not isinstance(stmt.target, ast.Name) or \
+        stmt.iter.func.id != "range" or \
+        len(stmt.iter.args) not in (1, 2):
+        raise StructureException("For statements must be of the form `for i in range(rounds): ..` or `for i in range(start, start + rounds): ..`", stmt.iter)
+    # Type 1 for, eg. for i in range(10): ...
+    if len(stmt.iter.args) == 1:
+        if not isinstance(stmt.iter.args[0], ast.Num):
+            raise StructureException("Repeat must have a nonzero positive integral number of rounds", stmt.iter)
+        start = LLLnode.from_list(0, typ='num', pos=getpos(stmt))
+        rounds = stmt.iter.args[0].n
+    elif isinstance(stmt.iter.args[0], ast.Num) and isinstance(stmt.iter.args[1], ast.Num):
+        # Type 2 for, eg. for i in range(100, 110): ...
+        start = LLLnode.from_list(stmt.iter.args[0].n, typ='num', pos=getpos(stmt))
+        rounds = LLLnode.from_list(stmt.iter.args[1].n - stmt.iter.args[0].n, typ='num', pos=getpos(stmt))
+    else:
+        # Type 3 for, eg. for i in range(x, x + 10): ...
+        if not isinstance(stmt.iter.args[1], ast.BinOp) or not isinstance(stmt.iter.args[1].op, ast.Add):
+            raise StructureException("Two-arg for statements must be of the form `for i in range(start, start + rounds): ...`",
+                                        stmt.iter.args[1])
+        if ast.dump(stmt.iter.args[0]) != ast.dump(stmt.iter.args[1].left):
+            raise StructureException("Two-arg for statements of the form `for i in range(x, x + y): ...` must have x identical in both places: %r %r" % (ast.dump(stmt.iter.args[0]), ast.dump(stmt.iter.args[1].left)), stmt.iter)
+        if not isinstance(stmt.iter.args[1].right, ast.Num):
+            raise StructureException("Repeat must have a nonzero positive integral number of rounds", stmt.iter.args[1])
+        start = parse_value_expr(stmt.iter.args[0], context)
+        rounds = stmt.iter.args[1].right.n
+    varname = stmt.target.id
+    pos = context.vars[varname].pos if varname in context.forvars else context.new_variable(varname, BaseType('num'))
+    o = LLLnode.from_list(['repeat', pos, start, rounds, parse_body(stmt.body, context)], typ=None, pos=getpos(stmt))
+    context.forvars[varname] = True
+    return o
+
+
+def parse_stmt_aug_assign(stmt, context):
+    target = parse_variable_location(stmt.target, context)
+    sub = parse_value_expr(stmt.value, context)
+    if not isinstance(stmt.op, (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod)):
+        raise Exception("Unsupported operator for augassign")
+    if not isinstance(target.typ, BaseType):
+        raise TypeMismatchException("Can only use aug-assign operators with simple types!", stmt.target)
+    if target.location == 'storage':
+        if context.is_constant:
+            raise ConstancyViolationException("Cannot modify storage inside a constant function!", stmt.target)
+        o = parse_value_expr(ast.BinOp(left=LLLnode.from_list(['sload', '_stloc'], typ=target.typ, pos=target.pos),
+                                right=sub, op=stmt.op, lineno=stmt.lineno, col_offset=stmt.col_offset), context)
+        return LLLnode.from_list(['with', '_stloc', target, ['sstore', '_stloc', base_type_conversion(o, o.typ, target.typ)]], typ=None, pos=getpos(stmt))
+    elif target.location == 'memory':
+        o = parse_value_expr(ast.BinOp(left=LLLnode.from_list(['mload', '_mloc'], typ=target.typ, pos=target.pos),
+                                right=sub, op=stmt.op, lineno=stmt.lineno, col_offset=stmt.col_offset), context)
+        return LLLnode.from_list(['with', '_mloc', target, ['mstore', '_mloc', base_type_conversion(o, o.typ, target.typ)]], typ=None, pos=getpos(stmt))
+
+
+def parse_stmt_break(stmt, context):
+    return LLLnode.from_list('break', typ=None, pos=getpos(stmt))
+
+
+def parse_stmt_return(stmt, context):
+    if context.return_type is None:
+        if stmt.value:
+            raise TypeMismatchException("Not expecting to return a value", stmt)
+        return LLLnode.from_list(['return', 0, 0], typ=None, pos=getpos(stmt))
+    if not stmt.value:
+        raise TypeMismatchException("Expecting to return a value", stmt)
+    sub = parse_expr(stmt.value, context)
+    # Returning a value (most common case)
+    if isinstance(sub.typ, BaseType):
+        if not isinstance(context.return_type, BaseType):
+            raise TypeMismatchException("Trying to return base type %r, output expecting %r" % (sub.typ, context.return_type), stmt.value)
+        sub = unwrap_location(sub)
+        if not are_units_compatible(sub.typ, context.return_type):
+            raise TypeMismatchException("Return type units mismatch %r %r" % (sub.typ, context.return_type), stmt.value)
+        elif is_base_type(sub.typ, context.return_type.typ) or \
+                (is_base_type(sub.typ, 'num') and is_base_type(context.return_type, 'signed256')):
+            return LLLnode.from_list(['seq', ['mstore', 0, sub], ['return', 0, 32]], typ=None, pos=getpos(stmt))
+        else:
+            raise TypeMismatchException("Unsupported type conversion: %r to %r" % (sub.typ, context.return_type), stmt.value)
+    # Returning a byte array
+    elif isinstance(sub.typ, ByteArrayType):
+        if not isinstance(context.return_type, ByteArrayType):
+            raise TypeMismatchException("Trying to return base type %r, output expecting %r" % (sub.typ, context.return_type), stmt.value)
+        if sub.typ.maxlen > context.return_type.maxlen:
+            raise TypeMismatchException("Cannot cast from greater max-length %d to shorter max-length %d" %
+                                        (sub.typ.maxlen, context.return_type.maxlen), stmt.value)
+        # Returning something already in memory
+        if sub.location == 'memory':
+            return LLLnode.from_list(['with', '_loc', sub,
+                                        ['seq',
+                                            ['mstore', ['sub', '_loc', 32], 32],
+                                            ['return', ['sub', '_loc', 32], ['ceil32', ['add', ['mload', '_loc'], 64]]]]], typ=None, pos=getpos(stmt))
+        # Copying from storage
+        elif sub.location == 'storage':
+            # Instantiate a byte array at some index
+            fake_byte_array = LLLnode(context.get_next_mem() + 32, typ=sub.typ, location='memory', pos=getpos(stmt))
+            o = ['seq',
+                    # Copy the data to this byte array
+                    make_byte_array_copier(fake_byte_array, sub),
+                    # Store the number 32 before it for ABI formatting purposes
+                    ['mstore', context.get_next_mem(), 32],
+                    # Return it
+                    ['return', context.get_next_mem(), ['add', ['ceil32', ['mload', context.get_next_mem() + 32]], 64]]]
+            return LLLnode.from_list(o, typ=None, pos=getpos(stmt))
+        else:
+            raise Exception("Invalid location: %s" % sub.location)
+    # Returning a list
+    elif isinstance(sub.typ, ListType):
+        if sub.location == "memory" and sub.value != "multi":
+            return LLLnode.from_list(['return', sub, get_size_of_type(context.return_type) * 32],
+                                        typ=None, pos=getpos(stmt))
+        else:
+            new_sub = LLLnode.from_list(context.new_placeholder(context.return_type), typ=context.return_type, location='memory')
+            setter = make_setter(new_sub, sub, 'memory')
+            return LLLnode.from_list(['seq', setter, ['return', new_sub, get_size_of_type(context.return_type) * 32]],
+                                        typ=None, pos=getpos(stmt))
+    else:
+        raise TypeMismatchException("Can only return base type!", stmt)
+
+parser_stmt_table = {
+    ast.Expr: parse_stmt_expr,
+    ast.Pass: parse_stmt_pass,
+    ast.AnnAssign: parse_stmt_ann_assign,
+    ast.Assign: parse_stmt_assign,
+    ast.If: parse_stmt_if,
+    ast.Call: parse_stmt_call,
+    ast.Assert: parse_stmt_assert,
+    ast.For: parse_stmt_for,
+    ast.AugAssign: parse_stmt_aug_assign,
+    ast.Break: parse_stmt_break,
+    ast.Return: parse_stmt_return,
+}
 
 # Parse a statement (usually one line of code but not always)
 def parse_stmt(stmt, context):
-    if isinstance(stmt, ast.Expr):
-        return parse_stmt(stmt.value, context)
-    elif isinstance(stmt, ast.Pass):
-        return LLLnode.from_list('pass', typ=None, pos=getpos(stmt))
-    elif isinstance(stmt, ast.AnnAssign):
-        typ = parse_type(stmt.annotation, location='memory')
-        varname = stmt.target.id
-        pos = context.new_variable(varname, typ)
-        return LLLnode.from_list('pass', typ=None, pos=getpos(stmt))
-    elif isinstance(stmt, ast.Assign):
-        # Assignment (eg. x[4] = y)
-        if len(stmt.targets) != 1:
-            raise StructureException("Assignment statement must have one target", stmt)
-        sub = parse_expr(stmt.value, context)
-        if isinstance(stmt.targets[0], ast.Name) and stmt.targets[0].id not in context.vars:
-            pos = context.new_variable(stmt.targets[0].id, set_default_units(sub.typ))
-            variable_loc = LLLnode.from_list(pos, typ=sub.typ, location='memory', pos=getpos(stmt), annotation=stmt.targets[0].id)
-            o = make_setter(variable_loc, sub, 'memory')
-        else:
-            target = parse_variable_location(stmt.targets[0], context)
-            if target.location == 'storage' and context.is_constant:
-                raise ConstancyViolationException("Cannot modify storage inside a constant function!", stmt.targets[0])
-            if not target.mutable:
-                raise ConstancyViolationException("Cannot modify function argument", stmt.targets[0])
-            o = make_setter(target, sub, target.location)
-        o.pos = getpos(stmt)
-        return o
+    stmt_type = stmt.__class__
+    if stmt_type in parser_stmt_table:
+        return parser_stmt_table[stmt_type](stmt, context)
+    # elif isinstance(stmt, ast.AnnAssign):
+    # elif isinstance(stmt, ast.Assign):
     # If statements
-    elif isinstance(stmt, ast.If):
-        if stmt.orelse:
-            return LLLnode.from_list(['if',
-                                      parse_value_expr(stmt.test, context),
-                                      parse_body(stmt.body, context),
-                                      parse_body(stmt.orelse, context)], typ=None, pos=getpos(stmt))
-        else:
-            return LLLnode.from_list(['if',
-                                      parse_value_expr(stmt.test, context),
-                                      parse_body(stmt.body, context)], typ=None, pos=getpos(stmt))
+    # elif isinstance(stmt, ast.If):
     # Calls
-    elif isinstance(stmt, ast.Call):
-        if isinstance(stmt.func, ast.Name) and stmt.func.id in stmt_dispatch_table:
-            return stmt_dispatch_table[stmt.func.id](stmt, context)
-        elif isinstance(stmt.func, ast.Attribute) and isinstance(stmt.func.value, ast.Name) and stmt.func.value.id == "self":
-            if stmt.func.attr not in context.sigs['self']:
-                raise VariableDeclarationException("Function not declared yet (reminder: functions cannot "
-                                                   "call functions later in code than themselves): %s" % stmt.func.attr)
-            inargs, inargsize = pack_arguments(context.sigs['self'][stmt.func.attr],
-                                               [parse_expr(arg, context) for arg in stmt.args],
-                                               context)
-            return LLLnode.from_list(['assert', ['call', ['gas'], ['address'], 0, inargs, inargsize, 0, 0]],
-                                     typ=None, pos=getpos(stmt))
-        elif isinstance(stmt.func, ast.Attribute) and isinstance(stmt.func.value, ast.Call):
-            return external_contract_call_stmt(stmt, context)
-        elif isinstance(stmt.func, ast.Attribute) and stmt.func.value.id == 'log':
-            if stmt.func.attr not in context.sigs['self']:
-                raise VariableDeclarationException("Event not declared yet: %s" % stmt.func.attr)
-            event = context.sigs['self'][stmt.func.attr]
-            topics, stored_topics, event, data = pack_logging_topics(event, stmt.args, context)
-            inargs, inargsize, inarg_start = pack_logging_data(event, data, context)
-            return LLLnode.from_list(['seq', inargs, stored_topics, ["log" + str(len(topics)), inarg_start, inargsize] + topics], typ=None, pos=getpos(stmt))
-        else:
-            raise StructureException("Unsupported operator: %r" % ast.dump(stmt), stmt)
+    # elif isinstance(stmt, ast.Call):
     # Asserts
-    elif isinstance(stmt, ast.Assert):
-        return LLLnode.from_list(['assert', parse_value_expr(stmt.test, context)], typ=None, pos=getpos(stmt))
+    # elif isinstance(stmt, ast.Assert):
     # for i in range(n): ... (note: n must be a nonzero positive constant integer)
-    elif isinstance(stmt, ast.For):
-        if not isinstance(stmt.iter, ast.Call) or \
-                not isinstance(stmt.iter.func, ast.Name) or \
-                not isinstance(stmt.target, ast.Name) or \
-                stmt.iter.func.id != "range" or \
-                len(stmt.iter.args) not in (1, 2):
-            raise StructureException("For statements must be of the form `for i in range(rounds): ..` or `for i in range(start, start + rounds): ..`", stmt.iter)
-        # Type 1 for, eg. for i in range(10): ...
-        if len(stmt.iter.args) == 1:
-            if not isinstance(stmt.iter.args[0], ast.Num):
-                raise StructureException("Repeat must have a nonzero positive integral number of rounds", stmt.iter)
-            start = LLLnode.from_list(0, typ='num', pos=getpos(stmt))
-            rounds = stmt.iter.args[0].n
-        elif isinstance(stmt.iter.args[0], ast.Num) and isinstance(stmt.iter.args[1], ast.Num):
-            # Type 2 for, eg. for i in range(100, 110): ...
-            start = LLLnode.from_list(stmt.iter.args[0].n, typ='num', pos=getpos(stmt))
-            rounds = LLLnode.from_list(stmt.iter.args[1].n - stmt.iter.args[0].n, typ='num', pos=getpos(stmt))
-        else:
-            # Type 3 for, eg. for i in range(x, x + 10): ...
-            if not isinstance(stmt.iter.args[1], ast.BinOp) or not isinstance(stmt.iter.args[1].op, ast.Add):
-                raise StructureException("Two-arg for statements must be of the form `for i in range(start, start + rounds): ...`",
-                                         stmt.iter.args[1])
-            if ast.dump(stmt.iter.args[0]) != ast.dump(stmt.iter.args[1].left):
-                raise StructureException("Two-arg for statements of the form `for i in range(x, x + y): ...` must have x identical in both places: %r %r" % (ast.dump(stmt.iter.args[0]), ast.dump(stmt.iter.args[1].left)), stmt.iter)
-            if not isinstance(stmt.iter.args[1].right, ast.Num):
-                raise StructureException("Repeat must have a nonzero positive integral number of rounds", stmt.iter.args[1])
-            start = parse_value_expr(stmt.iter.args[0], context)
-            rounds = stmt.iter.args[1].right.n
-        varname = stmt.target.id
-        pos = context.vars[varname].pos if varname in context.forvars else context.new_variable(varname, BaseType('num'))
-        o = LLLnode.from_list(['repeat', pos, start, rounds, parse_body(stmt.body, context)], typ=None, pos=getpos(stmt))
-        context.forvars[varname] = True
-        return o
+    # elif isinstance(stmt, ast.For):
     # +=, *=, etc
-    elif isinstance(stmt, ast.AugAssign):
-        target = parse_variable_location(stmt.target, context)
-        sub = parse_value_expr(stmt.value, context)
-        if not isinstance(stmt.op, (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod)):
-            raise Exception("Unsupported operator for augassign")
-        if not isinstance(target.typ, BaseType):
-            raise TypeMismatchException("Can only use aug-assign operators with simple types!", stmt.target)
-        if target.location == 'storage':
-            if context.is_constant:
-                raise ConstancyViolationException("Cannot modify storage inside a constant function!", stmt.target)
-            o = parse_value_expr(ast.BinOp(left=LLLnode.from_list(['sload', '_stloc'], typ=target.typ, pos=target.pos),
-                                 right=sub, op=stmt.op, lineno=stmt.lineno, col_offset=stmt.col_offset), context)
-            return LLLnode.from_list(['with', '_stloc', target, ['sstore', '_stloc', base_type_conversion(o, o.typ, target.typ)]], typ=None, pos=getpos(stmt))
-        elif target.location == 'memory':
-            o = parse_value_expr(ast.BinOp(left=LLLnode.from_list(['mload', '_mloc'], typ=target.typ, pos=target.pos),
-                                 right=sub, op=stmt.op, lineno=stmt.lineno, col_offset=stmt.col_offset), context)
-            return LLLnode.from_list(['with', '_mloc', target, ['mstore', '_mloc', base_type_conversion(o, o.typ, target.typ)]], typ=None, pos=getpos(stmt))
+    # elif isinstance(stmt, ast.AugAssign):
     # Break from a loop
-    elif isinstance(stmt, ast.Break):
-        return LLLnode.from_list('break', typ=None, pos=getpos(stmt))
+    # elif isinstance(stmt, ast.Break):
     # Return statement
-    elif isinstance(stmt, ast.Return):
-        if context.return_type is None:
-            if stmt.value:
-                raise TypeMismatchException("Not expecting to return a value", stmt)
-            return LLLnode.from_list(['return', 0, 0], typ=None, pos=getpos(stmt))
-        if not stmt.value:
-            raise TypeMismatchException("Expecting to return a value", stmt)
-        sub = parse_expr(stmt.value, context)
-        # Returning a value (most common case)
-        if isinstance(sub.typ, BaseType):
-            if not isinstance(context.return_type, BaseType):
-                raise TypeMismatchException("Trying to return base type %r, output expecting %r" % (sub.typ, context.return_type), stmt.value)
-            sub = unwrap_location(sub)
-            if not are_units_compatible(sub.typ, context.return_type):
-                raise TypeMismatchException("Return type units mismatch %r %r" % (sub.typ, context.return_type), stmt.value)
-            elif is_base_type(sub.typ, context.return_type.typ) or \
-                    (is_base_type(sub.typ, 'num') and is_base_type(context.return_type, 'signed256')):
-                return LLLnode.from_list(['seq', ['mstore', 0, sub], ['return', 0, 32]], typ=None, pos=getpos(stmt))
-            else:
-                raise TypeMismatchException("Unsupported type conversion: %r to %r" % (sub.typ, context.return_type), stmt.value)
-        # Returning a byte array
-        elif isinstance(sub.typ, ByteArrayType):
-            if not isinstance(context.return_type, ByteArrayType):
-                raise TypeMismatchException("Trying to return base type %r, output expecting %r" % (sub.typ, context.return_type), stmt.value)
-            if sub.typ.maxlen > context.return_type.maxlen:
-                raise TypeMismatchException("Cannot cast from greater max-length %d to shorter max-length %d" %
-                                            (sub.typ.maxlen, context.return_type.maxlen), stmt.value)
-            # Returning something already in memory
-            if sub.location == 'memory':
-                return LLLnode.from_list(['with', '_loc', sub,
-                                            ['seq',
-                                                ['mstore', ['sub', '_loc', 32], 32],
-                                                ['return', ['sub', '_loc', 32], ['ceil32', ['add', ['mload', '_loc'], 64]]]]], typ=None, pos=getpos(stmt))
-            # Copying from storage
-            elif sub.location == 'storage':
-                # Instantiate a byte array at some index
-                fake_byte_array = LLLnode(context.get_next_mem() + 32, typ=sub.typ, location='memory', pos=getpos(stmt))
-                o = ['seq',
-                        # Copy the data to this byte array
-                        make_byte_array_copier(fake_byte_array, sub),
-                        # Store the number 32 before it for ABI formatting purposes
-                        ['mstore', context.get_next_mem(), 32],
-                        # Return it
-                        ['return', context.get_next_mem(), ['add', ['ceil32', ['mload', context.get_next_mem() + 32]], 64]]]
-                return LLLnode.from_list(o, typ=None, pos=getpos(stmt))
-            else:
-                raise Exception("Invalid location: %s" % sub.location)
-        # Returning a list
-        elif isinstance(sub.typ, ListType):
-            if sub.location == "memory" and sub.value != "multi":
-                return LLLnode.from_list(['return', sub, get_size_of_type(context.return_type) * 32],
-                                         typ=None, pos=getpos(stmt))
-            else:
-                new_sub = LLLnode.from_list(context.new_placeholder(context.return_type), typ=context.return_type, location='memory')
-                setter = make_setter(new_sub, sub, 'memory')
-                return LLLnode.from_list(['seq', setter, ['return', new_sub, get_size_of_type(context.return_type) * 32]],
-                                         typ=None, pos=getpos(stmt))
-        else:
-            raise TypeMismatchException("Can only return base type!", stmt)
+    # elif isinstance(stmt, ast.Return):
     elif isinstance(stmt, ast.Name) and stmt.id == "throw":
         return LLLnode.from_list(['assert', 0], typ=None, pos=getpos(stmt))
     else:

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -1,7 +1,6 @@
 import ast
 
 from viper.exceptions import (
-    ConstancyViolationException,
     InvalidLiteralException,
     NonPayableViolationException,
     StructureException,
@@ -17,8 +16,8 @@ from viper.signatures.event_signature import (
 )
 from viper.functions import (
     dispatch_table,
-    stmt_dispatch_table,
 )
+from .stmt import Stmt
 from .parser_utils import LLLnode
 from .parser_utils import (
     get_length,
@@ -49,7 +48,6 @@ from viper.types import (
 from viper.types import (
     are_units_compatible,
     combine_units,
-    set_default_units,
 )
 from viper.utils import (
     DECIMAL_DIVISOR,
@@ -950,222 +948,10 @@ def make_setter(left, right, location):
     else:
         raise Exception("Invalid type for setters")
 
-# Extracted parser functionality
-def parse_stmt_expr(stmt, context): 
-    return parse_stmt(stmt.value, context)
-
-
-def parse_stmt_pass(stmt, context):
-    return LLLnode.from_list('pass', typ=None, pos=getpos(stmt))
-
-
-def parse_stmt_ann_assign(stmt, context):
-    typ = parse_type(stmt.annotation, location='memory')
-    varname = stmt.target.id
-    pos = context.new_variable(varname, typ)
-    return LLLnode.from_list('pass', typ=None, pos=getpos(stmt))
-
-
-def parse_stmt_assign(stmt, context):
-# Assignment (eg. x[4] = y)
-    if len(stmt.targets) != 1:
-        raise StructureException("Assignment statement must have one target", stmt)
-    sub = parse_expr(stmt.value, context)
-    if isinstance(stmt.targets[0], ast.Name) and stmt.targets[0].id not in context.vars:
-        pos = context.new_variable(stmt.targets[0].id, set_default_units(sub.typ))
-        variable_loc = LLLnode.from_list(pos, typ=sub.typ, location='memory', pos=getpos(stmt), annotation=stmt.targets[0].id)
-        o = make_setter(variable_loc, sub, 'memory')
-    else:
-        target = parse_variable_location(stmt.targets[0], context)
-        if target.location == 'storage' and context.is_constant:
-            raise ConstancyViolationException("Cannot modify storage inside a constant function!", stmt.targets[0])
-        if not target.mutable:
-            raise ConstancyViolationException("Cannot modify function argument", stmt.targets[0])
-        o = make_setter(target, sub, target.location)
-    o.pos = getpos(stmt)
-    return o
-
-
-def parse_stmt_if(stmt, context):
-    if stmt.orelse:
-        add_on = [parse_body(stmt.orelse, context)]
-    else:
-        add_on = []
-    return LLLnode.from_list(['if',parse_value_expr(stmt.test, context),parse_body(stmt.body, context)] + add_on, typ=None, pos=getpos(stmt))
-
-
-def parse_stmt_call(stmt, context):
-    if isinstance(stmt.func, ast.Name) and stmt.func.id in stmt_dispatch_table:
-            return stmt_dispatch_table[stmt.func.id](stmt, context)
-    elif isinstance(stmt.func, ast.Attribute) and isinstance(stmt.func.value, ast.Name) and stmt.func.value.id == "self":
-        if stmt.func.attr not in context.sigs['self']:
-            raise VariableDeclarationException("Function not declared yet (reminder: functions cannot "
-                                                "call functions later in code than themselves): %s" % stmt.func.attr)
-        inargs, inargsize = pack_arguments(context.sigs['self'][stmt.func.attr],
-                                            [parse_expr(arg, context) for arg in stmt.args],
-                                            context)
-        return LLLnode.from_list(['assert', ['call', ['gas'], ['address'], 0, inargs, inargsize, 0, 0]],
-                                    typ=None, pos=getpos(stmt))
-    elif isinstance(stmt.func, ast.Attribute) and isinstance(stmt.func.value, ast.Call):
-        return external_contract_call_stmt(stmt, context)
-    elif isinstance(stmt.func, ast.Attribute) and stmt.func.value.id == 'log':
-        if stmt.func.attr not in context.sigs['self']:
-            raise VariableDeclarationException("Event not declared yet: %s" % stmt.func.attr)
-        event = context.sigs['self'][stmt.func.attr]
-        topics, stored_topics, event, data = pack_logging_topics(event, stmt.args, context)
-        inargs, inargsize, inarg_start = pack_logging_data(event, data, context)
-        return LLLnode.from_list(['seq', inargs, stored_topics, ["log" + str(len(topics)), inarg_start, inargsize] + topics], typ=None, pos=getpos(stmt))
-    else:
-        raise StructureException("Unsupported operator: %r" % ast.dump(stmt), stmt)
-
-
-def parse_stmt_assert(stmt, context):
-    return LLLnode.from_list(['assert', parse_value_expr(stmt.test, context)], typ=None, pos=getpos(stmt))
-
-
-def parse_stmt_for(stmt, context):
-    if not isinstance(stmt.iter, ast.Call) or \
-        not isinstance(stmt.iter.func, ast.Name) or \
-        not isinstance(stmt.target, ast.Name) or \
-        stmt.iter.func.id != "range" or \
-        len(stmt.iter.args) not in (1, 2):
-        raise StructureException("For statements must be of the form `for i in range(rounds): ..` or `for i in range(start, start + rounds): ..`", stmt.iter)
-    # Type 1 for, eg. for i in range(10): ...
-    if len(stmt.iter.args) == 1:
-        if not isinstance(stmt.iter.args[0], ast.Num):
-            raise StructureException("Repeat must have a nonzero positive integral number of rounds", stmt.iter)
-        start = LLLnode.from_list(0, typ='num', pos=getpos(stmt))
-        rounds = stmt.iter.args[0].n
-    elif isinstance(stmt.iter.args[0], ast.Num) and isinstance(stmt.iter.args[1], ast.Num):
-        # Type 2 for, eg. for i in range(100, 110): ...
-        start = LLLnode.from_list(stmt.iter.args[0].n, typ='num', pos=getpos(stmt))
-        rounds = LLLnode.from_list(stmt.iter.args[1].n - stmt.iter.args[0].n, typ='num', pos=getpos(stmt))
-    else:
-        # Type 3 for, eg. for i in range(x, x + 10): ...
-        if not isinstance(stmt.iter.args[1], ast.BinOp) or not isinstance(stmt.iter.args[1].op, ast.Add):
-            raise StructureException("Two-arg for statements must be of the form `for i in range(start, start + rounds): ...`",
-                                        stmt.iter.args[1])
-        if ast.dump(stmt.iter.args[0]) != ast.dump(stmt.iter.args[1].left):
-            raise StructureException("Two-arg for statements of the form `for i in range(x, x + y): ...` must have x identical in both places: %r %r" % (ast.dump(stmt.iter.args[0]), ast.dump(stmt.iter.args[1].left)), stmt.iter)
-        if not isinstance(stmt.iter.args[1].right, ast.Num):
-            raise StructureException("Repeat must have a nonzero positive integral number of rounds", stmt.iter.args[1])
-        start = parse_value_expr(stmt.iter.args[0], context)
-        rounds = stmt.iter.args[1].right.n
-    varname = stmt.target.id
-    pos = context.vars[varname].pos if varname in context.forvars else context.new_variable(varname, BaseType('num'))
-    o = LLLnode.from_list(['repeat', pos, start, rounds, parse_body(stmt.body, context)], typ=None, pos=getpos(stmt))
-    context.forvars[varname] = True
-    return o
-
-
-def parse_stmt_aug_assign(stmt, context):
-    target = parse_variable_location(stmt.target, context)
-    sub = parse_value_expr(stmt.value, context)
-    if not isinstance(stmt.op, (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod)):
-        raise Exception("Unsupported operator for augassign")
-    if not isinstance(target.typ, BaseType):
-        raise TypeMismatchException("Can only use aug-assign operators with simple types!", stmt.target)
-    if target.location == 'storage':
-        if context.is_constant:
-            raise ConstancyViolationException("Cannot modify storage inside a constant function!", stmt.target)
-        o = parse_value_expr(ast.BinOp(left=LLLnode.from_list(['sload', '_stloc'], typ=target.typ, pos=target.pos),
-                                right=sub, op=stmt.op, lineno=stmt.lineno, col_offset=stmt.col_offset), context)
-        return LLLnode.from_list(['with', '_stloc', target, ['sstore', '_stloc', base_type_conversion(o, o.typ, target.typ)]], typ=None, pos=getpos(stmt))
-    elif target.location == 'memory':
-        o = parse_value_expr(ast.BinOp(left=LLLnode.from_list(['mload', '_mloc'], typ=target.typ, pos=target.pos),
-                                right=sub, op=stmt.op, lineno=stmt.lineno, col_offset=stmt.col_offset), context)
-        return LLLnode.from_list(['with', '_mloc', target, ['mstore', '_mloc', base_type_conversion(o, o.typ, target.typ)]], typ=None, pos=getpos(stmt))
-
-
-def parse_stmt_break(stmt, context):
-    return LLLnode.from_list('break', typ=None, pos=getpos(stmt))
-
-
-def parse_stmt_return(stmt, context):
-    if context.return_type is None:
-        if stmt.value:
-            raise TypeMismatchException("Not expecting to return a value", stmt)
-        return LLLnode.from_list(['return', 0, 0], typ=None, pos=getpos(stmt))
-    if not stmt.value:
-        raise TypeMismatchException("Expecting to return a value", stmt)
-    sub = parse_expr(stmt.value, context)
-    # Returning a value (most common case)
-    if isinstance(sub.typ, BaseType):
-        if not isinstance(context.return_type, BaseType):
-            raise TypeMismatchException("Trying to return base type %r, output expecting %r" % (sub.typ, context.return_type), stmt.value)
-        sub = unwrap_location(sub)
-        if not are_units_compatible(sub.typ, context.return_type):
-            raise TypeMismatchException("Return type units mismatch %r %r" % (sub.typ, context.return_type), stmt.value)
-        elif is_base_type(sub.typ, context.return_type.typ) or \
-                (is_base_type(sub.typ, 'num') and is_base_type(context.return_type, 'signed256')):
-            return LLLnode.from_list(['seq', ['mstore', 0, sub], ['return', 0, 32]], typ=None, pos=getpos(stmt))
-        else:
-            raise TypeMismatchException("Unsupported type conversion: %r to %r" % (sub.typ, context.return_type), stmt.value)
-    # Returning a byte array
-    elif isinstance(sub.typ, ByteArrayType):
-        if not isinstance(context.return_type, ByteArrayType):
-            raise TypeMismatchException("Trying to return base type %r, output expecting %r" % (sub.typ, context.return_type), stmt.value)
-        if sub.typ.maxlen > context.return_type.maxlen:
-            raise TypeMismatchException("Cannot cast from greater max-length %d to shorter max-length %d" %
-                                        (sub.typ.maxlen, context.return_type.maxlen), stmt.value)
-        # Returning something already in memory
-        if sub.location == 'memory':
-            return LLLnode.from_list(['with', '_loc', sub,
-                                        ['seq',
-                                            ['mstore', ['sub', '_loc', 32], 32],
-                                            ['return', ['sub', '_loc', 32], ['ceil32', ['add', ['mload', '_loc'], 64]]]]], typ=None, pos=getpos(stmt))
-        # Copying from storage
-        elif sub.location == 'storage':
-            # Instantiate a byte array at some index
-            fake_byte_array = LLLnode(context.get_next_mem() + 32, typ=sub.typ, location='memory', pos=getpos(stmt))
-            o = ['seq',
-                    # Copy the data to this byte array
-                    make_byte_array_copier(fake_byte_array, sub),
-                    # Store the number 32 before it for ABI formatting purposes
-                    ['mstore', context.get_next_mem(), 32],
-                    # Return it
-                    ['return', context.get_next_mem(), ['add', ['ceil32', ['mload', context.get_next_mem() + 32]], 64]]]
-            return LLLnode.from_list(o, typ=None, pos=getpos(stmt))
-        else:
-            raise Exception("Invalid location: %s" % sub.location)
-    # Returning a list
-    elif isinstance(sub.typ, ListType):
-        if sub.location == "memory" and sub.value != "multi":
-            return LLLnode.from_list(['return', sub, get_size_of_type(context.return_type) * 32],
-                                        typ=None, pos=getpos(stmt))
-        else:
-            new_sub = LLLnode.from_list(context.new_placeholder(context.return_type), typ=context.return_type, location='memory')
-            setter = make_setter(new_sub, sub, 'memory')
-            return LLLnode.from_list(['seq', setter, ['return', new_sub, get_size_of_type(context.return_type) * 32]],
-                                        typ=None, pos=getpos(stmt))
-    else:
-        raise TypeMismatchException("Can only return base type!", stmt)
-
-
-parser_stmt_table = {
-    ast.Expr: parse_stmt_expr,
-    ast.Pass: parse_stmt_pass,
-    ast.AnnAssign: parse_stmt_ann_assign,
-    ast.Assign: parse_stmt_assign,
-    ast.If: parse_stmt_if,
-    ast.Call: parse_stmt_call,
-    ast.Assert: parse_stmt_assert,
-    ast.For: parse_stmt_for,
-    ast.AugAssign: parse_stmt_aug_assign,
-    ast.Break: parse_stmt_break,
-    ast.Return: parse_stmt_return,
-}
-
 
 # Parse a statement (usually one line of code but not always)
 def parse_stmt(stmt, context):
-    stmt_type = stmt.__class__
-    if stmt_type in parser_stmt_table:
-        return parser_stmt_table[stmt_type](stmt, context)
-    elif isinstance(stmt, ast.Name) and stmt.id == "throw":
-        return LLLnode.from_list(['assert', 0], typ=None, pos=getpos(stmt))
-    else:
-        raise StructureException("Unsupported statement type", stmt)
+    return Stmt(stmt, context).lll_node
 
 
 def pack_logging_topics(event, args, context):

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -1,6 +1,6 @@
 import ast
 
-from .exceptions import (
+from viper.exceptions import (
     ConstancyViolationException,
     InvalidLiteralException,
     NonPayableViolationException,
@@ -8,14 +8,14 @@ from .exceptions import (
     TypeMismatchException,
     VariableDeclarationException,
 )
-from .function_signature import (
+from viper.function_signature import (
     FunctionSignature,
     VariableRecord,
 )
-from .signatures.event_signature import (
+from viper.signatures.event_signature import (
     EventSignature
 )
-from .functions import (
+from viper.functions import (
     dispatch_table,
     stmt_dispatch_table,
 )
@@ -30,7 +30,7 @@ from .parser_utils import (
     base_type_conversion,
     unwrap_location
 )
-from .types import (
+from viper.types import (
     BaseType,
     ByteArrayType,
     ListType,
@@ -40,18 +40,18 @@ from .types import (
     StructType,
     TupleType,
 )
-from .types import (
+from viper.types import (
     get_size_of_type,
     is_base_type,
     is_numeric_type,
     parse_type,
 )
-from .types import (
+from viper.types import (
     are_units_compatible,
     combine_units,
     set_default_units,
 )
-from .utils import (
+from viper.utils import (
     DECIMAL_DIVISOR,
     RESERVED_MEMORY,
     ADDRSIZE_POS,
@@ -60,7 +60,7 @@ from .utils import (
     MAXDECIMAL_POS,
     MINDECIMAL_POS,
 )
-from .utils import (
+from viper.utils import (
     bytes_to_int,
     checksum_encode,
     calc_mem_gas,
@@ -1141,6 +1141,7 @@ def parse_stmt_return(stmt, context):
     else:
         raise TypeMismatchException("Can only return base type!", stmt)
 
+
 parser_stmt_table = {
     ast.Expr: parse_stmt_expr,
     ast.Pass: parse_stmt_pass,
@@ -1155,27 +1156,12 @@ parser_stmt_table = {
     ast.Return: parse_stmt_return,
 }
 
+
 # Parse a statement (usually one line of code but not always)
 def parse_stmt(stmt, context):
     stmt_type = stmt.__class__
     if stmt_type in parser_stmt_table:
         return parser_stmt_table[stmt_type](stmt, context)
-    # elif isinstance(stmt, ast.AnnAssign):
-    # elif isinstance(stmt, ast.Assign):
-    # If statements
-    # elif isinstance(stmt, ast.If):
-    # Calls
-    # elif isinstance(stmt, ast.Call):
-    # Asserts
-    # elif isinstance(stmt, ast.Assert):
-    # for i in range(n): ... (note: n must be a nonzero positive constant integer)
-    # elif isinstance(stmt, ast.For):
-    # +=, *=, etc
-    # elif isinstance(stmt, ast.AugAssign):
-    # Break from a loop
-    # elif isinstance(stmt, ast.Break):
-    # Return statement
-    # elif isinstance(stmt, ast.Return):
     elif isinstance(stmt, ast.Name) and stmt.id == "throw":
         return LLLnode.from_list(['assert', 0], typ=None, pos=getpos(stmt))
     else:

--- a/viper/parser/parser_utils.py
+++ b/viper/parser/parser_utils.py
@@ -1,8 +1,8 @@
 import re
 
-from .exceptions import TypeMismatchException
-from .opcodes import comb_opcodes
-from .types import (
+from viper.exceptions import TypeMismatchException
+from viper.opcodes import comb_opcodes
+from viper.types import (
     BaseType,
     ByteArrayType,
     NodeType,
@@ -12,18 +12,18 @@ from .types import (
     TupleType,
     ListType,
 )
-from .types import (
+from viper.types import (
     is_base_type,
     are_units_compatible,
     get_size_of_type
 )
-from .utils import (
+from viper.utils import (
     MAXNUM_POS,
     MINNUM_POS,
     FREE_LOOP_INDEX,
     DECIMAL_DIVISOR,
 )
-from .utils import ceil32
+from viper.utils import ceil32
 
 
 class NullAttractor():

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -1,0 +1,269 @@
+import ast
+
+from viper.exceptions import (
+    ConstancyViolationException,
+    StructureException,
+    TypeMismatchException,
+    VariableDeclarationException,
+)
+from viper.functions import (
+    stmt_dispatch_table,
+)
+from .parser_utils import LLLnode
+from .parser_utils import (
+    getpos,
+    make_byte_array_copier,
+    base_type_conversion,
+    unwrap_location
+)
+from viper.types import (
+    BaseType,
+    ByteArrayType,
+    ListType,
+)
+from viper.types import (
+    get_size_of_type,
+    is_base_type,
+    parse_type,
+)
+from viper.types import (
+    are_units_compatible,
+    set_default_units,
+)
+
+
+class Stmt(object):
+    def __init__(self, stmt, context):
+        self.stmt = stmt
+        self.context = context
+        self.stmt_table = {
+            ast.Expr: self.expr,
+            ast.Pass: self.parse_pass,
+            ast.AnnAssign: self.ann_assign,
+            ast.Assign: self.assign,
+            ast.If: self.parse_if,
+            ast.Call: self.call,
+            ast.Assert: self.parse_assert,
+            ast.For: self.parse_for,
+            ast.AugAssign: self.aug_assign,
+            ast.Break: self.parse_break,
+            ast.Return: self.parse_return,
+        }
+        stmt_type = self.stmt.__class__
+        if stmt_type in self.stmt_table:
+            self.lll_node = self.stmt_table[stmt_type]()
+        elif isinstance(stmt, ast.Name) and stmt.id == "throw":
+            self.lll_node = LLLnode.from_list(['assert', 0], typ=None, pos=getpos(stmt))
+        else:
+            raise StructureException("Unsupported statement type", stmt)
+
+    def expr(self):
+        return Stmt(self.stmt.value, self.context).lll_node
+
+    def parse_pass(self):
+        return LLLnode.from_list('pass', typ=None, pos=getpos(self.stmt))
+
+    def ann_assign(self):
+        typ = parse_type(self.stmt.annotation, location='memory')
+        varname = self.stmt.target.id
+        pos = self.context.new_variable(varname, typ)
+        return LLLnode.from_list('pass', typ=None, pos=pos)
+
+    def assign(self):
+        from .parser import (
+            parse_expr,
+            parse_variable_location,
+            make_setter,
+        )
+        # Assignment (eg. x[4] = y)
+        if len(self.stmt.targets) != 1:
+            raise StructureException("Assignment statement must have one target", self.stmt)
+        sub = parse_expr(self.stmt.value, self.context)
+        if isinstance(self.stmt.targets[0], ast.Name) and self.stmt.targets[0].id not in self.context.vars:
+            pos = self.context.new_variable(self.stmt.targets[0].id, set_default_units(sub.typ))
+            variable_loc = LLLnode.from_list(pos, typ=sub.typ, location='memory', pos=getpos(self.stmt), annotation=self.stmt.targets[0].id)
+            o = make_setter(variable_loc, sub, 'memory')
+        else:
+            target = parse_variable_location(self.stmt.targets[0], self.context)
+            if target.location == 'storage' and self.context.is_constant:
+                raise ConstancyViolationException("Cannot modify storage inside a constant function!", self.stmt.targets[0])
+            if not target.mutable:
+                raise ConstancyViolationException("Cannot modify function argument", self.stmt.targets[0])
+            o = make_setter(target, sub, target.location)
+        o.pos = getpos(self.stmt)
+        return o
+
+    def parse_if(self):
+        from .parser import (
+            parse_value_expr,
+            parse_body,
+        )
+        if self.stmt.orelse:
+            add_on = [parse_body(self.stmt.orelse, self.context)]
+        else:
+            add_on = []
+        return LLLnode.from_list(['if', parse_value_expr(self.stmt.test, self.context), parse_body(self.stmt.body, self.context)] + add_on, typ=None, pos=getpos(self.stmt))
+
+    def call(self):
+        from .parser import (
+            parse_expr,
+            pack_arguments,
+            pack_logging_data,
+            pack_logging_topics,
+            external_contract_call_stmt,
+        )
+        if isinstance(self.stmt.func, ast.Name) and self.stmt.func.id in stmt_dispatch_table:
+                return stmt_dispatch_table[self.stmt.func.id](self.stmt, self.context)
+        elif isinstance(self.stmt.func, ast.Attribute) and isinstance(self.stmt.func.value, ast.Name) and self.stmt.func.value.id == "self":
+            if self.stmt.func.attr not in self.context.sigs['self']:
+                raise VariableDeclarationException("Function not declared yet (reminder: functions cannot "
+                                                    "call functions later in code than themselves): %s" % self.stmt.func.attr)
+            inargs, inargsize = pack_arguments(self.context.sigs['self'][self.stmt.func.attr],
+                                                [parse_expr(arg, self.context) for arg in self.stmt.args],
+                                                self.context)
+            return LLLnode.from_list(['assert', ['call', ['gas'], ['address'], 0, inargs, inargsize, 0, 0]],
+                                        typ=None, pos=getpos(self.stmt))
+        elif isinstance(self.stmt.func, ast.Attribute) and isinstance(self.stmt.func.value, ast.Call):
+            return external_contract_call_stmt(self.stmt, self.context)
+        elif isinstance(self.stmt.func, ast.Attribute) and self.stmt.func.value.id == 'log':
+            if self.stmt.func.attr not in self.context.sigs['self']:
+                raise VariableDeclarationException("Event not declared yet: %s" % self.stmt.func.attr)
+            event = self.context.sigs['self'][self.stmt.func.attr]
+            topics, stored_topics, event, data = pack_logging_topics(event, self.stmt.args, self.context)
+            inargs, inargsize, inarg_start = pack_logging_data(event, data, self.context)
+            return LLLnode.from_list(['seq', inargs, stored_topics, ["log" + str(len(topics)), inarg_start, inargsize] + topics], typ=None, pos=getpos(self.stmt))
+        else:
+            raise StructureException("Unsupported operator: %r" % ast.dump(self.stmt), self.stmt)
+
+    def parse_assert(self):
+        from .parser import (
+            parse_value_expr
+        )
+        return LLLnode.from_list(['assert', parse_value_expr(self.stmt.test, self.context)], typ=None, pos=getpos(self.stmt))
+
+    def parse_for(self):
+        from .parser import (
+            parse_value_expr,
+            parse_body,
+        )
+        if not isinstance(self.stmt.iter, ast.Call) or \
+            not isinstance(self.stmt.iter.func, ast.Name) or \
+                not isinstance(self.stmt.target, ast.Name) or \
+                    self.stmt.iter.func.id != "range" or \
+                        len(self.stmt.iter.args) not in (1, 2):
+            raise StructureException("For statements must be of the form `for i in range(rounds): ..` or `for i in range(start, start + rounds): ..`", self.stmt.iter)
+        # Type 1 for, eg. for i in range(10): ...
+        if len(self.stmt.iter.args) == 1:
+            if not isinstance(self.stmt.iter.args[0], ast.Num):
+                raise StructureException("Repeat must have a nonzero positive integral number of rounds", self.stmt.iter)
+            start = LLLnode.from_list(0, typ='num', pos=getpos(self.stmt))
+            rounds = self.stmt.iter.args[0].n
+        elif isinstance(self.stmt.iter.args[0], ast.Num) and isinstance(self.stmt.iter.args[1], ast.Num):
+            # Type 2 for, eg. for i in range(100, 110): ...
+            start = LLLnode.from_list(self.stmt.iter.args[0].n, typ='num', pos=getpos(self.stmt))
+            rounds = LLLnode.from_list(self.stmt.iter.args[1].n - self.stmt.iter.args[0].n, typ='num', pos=getpos(self.stmt))
+        else:
+            # Type 3 for, eg. for i in range(x, x + 10): ...
+            if not isinstance(self.stmt.iter.args[1], ast.BinOp) or not isinstance(self.stmt.iter.args[1].op, ast.Add):
+                raise StructureException("Two-arg for statements must be of the form `for i in range(start, start + rounds): ...`",
+                                            self.stmt.iter.args[1])
+            if ast.dump(self.stmt.iter.args[0]) != ast.dump(self.stmt.iter.args[1].left):
+                raise StructureException("Two-arg for statements of the form `for i in range(x, x + y): ...` must have x identical in both places: %r %r" % (ast.dump(self.stmt.iter.args[0]), ast.dump(self.stmt.iter.args[1].left)), self.stmt.iter)
+            if not isinstance(self.stmt.iter.args[1].right, ast.Num):
+                raise StructureException("Repeat must have a nonzero positive integral number of rounds", self.stmt.iter.args[1])
+            start = parse_value_expr(self.stmt.iter.args[0], self.context)
+            rounds = self.stmt.iter.args[1].right.n
+        varname = self.stmt.target.id
+        pos = self.context.vars[varname].pos if varname in self.context.forvars else self.context.new_variable(varname, BaseType('num'))
+        o = LLLnode.from_list(['repeat', pos, start, rounds, parse_body(self.stmt.body, self.context)], typ=None, pos=getpos(self.stmt))
+        self.context.forvars[varname] = True
+        return o
+
+    def aug_assign(self):
+        from .parser import (
+            parse_variable_location,
+            parse_value_expr,
+        )
+        target = parse_variable_location(self.stmt.target, self.context)
+        sub = parse_value_expr(self.stmt.value, self.context)
+        if not isinstance(self.stmt.op, (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod)):
+            raise Exception("Unsupported operator for augassign")
+        if not isinstance(target.typ, BaseType):
+            raise TypeMismatchException("Can only use aug-assign operators with simple types!", self.stmt.target)
+        if target.location == 'storage':
+            if self.context.is_constant:
+                raise ConstancyViolationException("Cannot modify storage inside a constant function!", self.stmt.target)
+            o = parse_value_expr(ast.BinOp(left=LLLnode.from_list(['sload', '_stloc'], typ=target.typ, pos=target.pos),
+                                    right=sub, op=self.stmt.op, lineno=self.stmt.lineno, col_offset=self.stmt.col_offset), self.context)
+            return LLLnode.from_list(['with', '_stloc', target, ['sstore', '_stloc', base_type_conversion(o, o.typ, target.typ)]], typ=None, pos=getpos(self.stmt))
+        elif target.location == 'memory':
+            o = parse_value_expr(ast.BinOp(left=LLLnode.from_list(['mload', '_mloc'], typ=target.typ, pos=target.pos),
+                                    right=sub, op=self.stmt.op, lineno=self.stmt.lineno, col_offset=self.stmt.col_offset), self.context)
+            return LLLnode.from_list(['with', '_mloc', target, ['mstore', '_mloc', base_type_conversion(o, o.typ, target.typ)]], typ=None, pos=getpos(self.stmt))
+
+    def parse_break(self):
+        return LLLnode.from_list('break', typ=None, pos=getpos(self.stmt))
+
+    def parse_return(self):
+        from .parser import (
+            parse_expr,
+            make_setter
+        )
+        if self.context.return_type is None:
+            if self.stmt.value:
+                raise TypeMismatchException("Not expecting to return a value", self.stmt)
+            return LLLnode.from_list(['return', 0, 0], typ=None, pos=getpos(self.stmt))
+        if not self.stmt.value:
+            raise TypeMismatchException("Expecting to return a value", self.stmt)
+        sub = parse_expr(self.stmt.value, self.context)
+        # Returning a value (most common case)
+        if isinstance(sub.typ, BaseType):
+            if not isinstance(self.context.return_type, BaseType):
+                raise TypeMismatchException("Trying to return base type %r, output expecting %r" % (sub.typ, self.context.return_type), self.stmt.value)
+            sub = unwrap_location(sub)
+            if not are_units_compatible(sub.typ, self.context.return_type):
+                raise TypeMismatchException("Return type units mismatch %r %r" % (sub.typ, self.context.return_type), self.stmt.value)
+            elif is_base_type(sub.typ, self.context.return_type.typ) or \
+                    (is_base_type(sub.typ, 'num') and is_base_type(self.context.return_type, 'signed256')):
+                return LLLnode.from_list(['seq', ['mstore', 0, sub], ['return', 0, 32]], typ=None, pos=getpos(self.stmt))
+            else:
+                raise TypeMismatchException("Unsupported type conversion: %r to %r" % (sub.typ, self.context.return_type), self.stmt.value)
+        # Returning a byte array
+        elif isinstance(sub.typ, ByteArrayType):
+            if not isinstance(self.context.return_type, ByteArrayType):
+                raise TypeMismatchException("Trying to return base type %r, output expecting %r" % (sub.typ, self.context.return_type), self.stmt.value)
+            if sub.typ.maxlen > self.context.return_type.maxlen:
+                raise TypeMismatchException("Cannot cast from greater max-length %d to shorter max-length %d" %
+                                            (sub.typ.maxlen, self.context.return_type.maxlen), self.stmt.value)
+            # Returning something already in memory
+            if sub.location == 'memory':
+                return LLLnode.from_list(['with', '_loc', sub,
+                                            ['seq',
+                                                ['mstore', ['sub', '_loc', 32], 32],
+                                                ['return', ['sub', '_loc', 32], ['ceil32', ['add', ['mload', '_loc'], 64]]]]], typ=None, pos=getpos(self.stmt))
+            # Copying from storage
+            elif sub.location == 'storage':
+                # Instantiate a byte array at some index
+                fake_byte_array = LLLnode(self.context.get_next_mem() + 32, typ=sub.typ, location='memory', pos=getpos(self.stmt))
+                o = ['seq',
+                        # Copy the data to this byte array
+                        make_byte_array_copier(fake_byte_array, sub),
+                        # Store the number 32 before it for ABI formatting purposes
+                        ['mstore', self.context.get_next_mem(), 32],
+                        # Return it
+                        ['return', self.context.get_next_mem(), ['add', ['ceil32', ['mload', self.context.get_next_mem() + 32]], 64]]]
+                return LLLnode.from_list(o, typ=None, pos=getpos(self.stmt))
+            else:
+                raise Exception("Invalid location: %s" % sub.location)
+        # Returning a list
+        elif isinstance(sub.typ, ListType):
+            if sub.location == "memory" and sub.value != "multi":
+                return LLLnode.from_list(['return', sub, get_size_of_type(self.context.return_type) * 32],
+                                            typ=None, pos=getpos(self.stmt))
+            else:
+                new_sub = LLLnode.from_list(self.context.new_placeholder(self.context.return_type), typ=self.context.return_type, location='memory')
+                setter = make_setter(new_sub, sub, 'memory')
+                return LLLnode.from_list(['seq', setter, ['return', new_sub, get_size_of_type(self.context.return_type) * 32]],
+                                            typ=None, pos=getpos(self.stmt))
+        else:
+            raise TypeMismatchException("Can only return base type!", self.stmt)

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -33,6 +33,7 @@ from viper.types import (
 
 
 class Stmt(object):
+    # TODO: Once other refactors are made reevaluate all inline imports
     def __init__(self, stmt, context):
         self.stmt = stmt
         self.context = context


### PR DESCRIPTION
### - What I did
I broke the `parse_stmt` method out into it's own class.

### - How I did it
1) Turned the `parse_stmt` conditional into a dictionary
2) Move `parser.py` into a parser folder
3) Create a seperate `stmt.py` file

### - How to verify it
Look through my PR to make sure my refactors increase simplicity and don't change any functionality.

### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/31060824-3922c798-a6d7-11e7-9675-1ee733336709.png)

