### PR TITLE
Fix travis and uncomment ec tests

### DIFF
--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -123,7 +123,8 @@ def foo():
     # # Event abi is created correctly
     assert c.translator.event_data[event_id] == {'types': ['int128[2]', 'int128[3]', 'int128[2][2]'], 'name': 'MyLog', 'names': ['arg1', 'arg2', 'arg3'], 'indexed': [False, False, False], 'anonymous': False}
     # # Event is decoded correctly
-    assert c.translator.decode_event(logs.topics, logs.data) == {'arg1': [1, 2], 'arg2': [1467446892, 1467446893, 1467446894], 'arg3': [[1, 2], [1, 2]], '_event_type': b'MyLog'}
+    timestamp = s.head_state.timestamp
+    assert c.translator.decode_event(logs.topics, logs.data) == {'arg1': [1, 2], 'arg2': [timestamp, timestamp + 1, timestamp + 2], 'arg3': [[1, 2], [1, 2]], '_event_type': b'MyLog'}
 
 
 def test_event_logging_with_data_with_different_types():
@@ -144,9 +145,8 @@ def foo():
     assert c.translator.event_data[event_id]
     # Event abi is created correctly
     assert c.translator.event_data[event_id] == {'types': ['int128', 'bytes4', 'bytes3', 'address', 'address', 'int128'], 'name': 'MyLog', 'names': ['arg1', 'arg2', 'arg3', 'arg4', 'arg5', 'arg6'], 'indexed': [False, False, False, False, False, False], 'anonymous': False}
-
     # Event is decoded correctly
-    assert c.translator.decode_event(logs.topics, logs.data) == {'arg1': 123, 'arg2': b'home', 'arg3': b'bar', 'arg4': '0xc305c901078781c232a2a521c2af7980f8385ee9', 'arg5': '0x' + c.address.hex(), 'arg6': 1467446892, '_event_type': b'MyLog'}
+    assert c.translator.decode_event(logs.topics, logs.data) == {'arg1': 123, 'arg2': b'home', 'arg3': b'bar', 'arg4': '0xc305c901078781c232a2a521c2af7980f8385ee9', 'arg5': '0x' + c.address.hex(), 'arg6': s.head_state.timestamp, '_event_type': b'MyLog'}
 
 
 def test_event_logging_with_topics_and_data():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -863,11 +863,10 @@ def _ecadd3(x: num256[2], y: num256[2]) -> num256[2]:
     """
     c = get_contract(ecadder)
 
-    # UNCOMMENT WHEN NEXT VERSION OF ETHEREUM IS RELEASED (these tests should pass then)
-    # assert c._ecadd(G1, G1) == G1_times_two
-    # assert c._ecadd2(G1, G1_times_two) == G1_times_three
-    # assert c._ecadd3(G1, [0, 0]) == G1
-    # assert c._ecadd3(G1, negative_G1) == [0, 0]
+    assert c._ecadd(G1, G1) == G1_times_two
+    assert c._ecadd2(G1, G1_times_two) == G1_times_three
+    assert c._ecadd3(G1, [0, 0]) == G1
+    assert c._ecadd3(G1, negative_G1) == [0, 0]
 
 def test_ecmul():
     ecmuller = """
@@ -890,12 +889,11 @@ def _ecmul3(x: num256[2], y: num256) -> num256[2]:
 """
     c = get_contract(ecmuller)
 
-    # UNCOMMENT WHEN NEXT VERSION OF ETHEREUM IS RELEASED (these tests should pass then)
-    # assert c._ecmul(G1, 0) == [0 ,0]
-    # assert c._ecmul(G1, 1) == G1
-    # assert c._ecmul(G1, 3) == G1_times_three
-    # assert c._ecmul(G1, curve_order - 1) == negative_G1
-    # assert c._ecmul(G1, curve_order) == [0, 0]
+    assert c._ecmul(G1, 0) == [0 ,0]
+    assert c._ecmul(G1, 1) == G1
+    assert c._ecmul(G1, 3) == G1_times_three
+    assert c._ecmul(G1, curve_order - 1) == negative_G1
+    assert c._ecmul(G1, curve_order) == [0, 0]
 
 def test_modmul():
     modexper = """

--- a/viper/__init__.py
+++ b/viper/__init__.py
@@ -1,7 +1,7 @@
 import sys
+from pkg_resources import get_distribution
 if (sys.version_info.major, sys.version_info.minor) < (3, 6):
     raise Exception("Requires python3.6+")
 
-from pkg_resources import get_distribution
 
 __version__ = get_distribution('viper').version

--- a/viper/signatures/__init__.py
+++ b/viper/signatures/__init__.py
@@ -1,1 +1,0 @@
-from . import event_signature


### PR DESCRIPTION
### - What I did
Fixed logging tests timestamps and flake8 formatting to get travis passing.
Then I uncommented `ecadd` and `ecmul` because they now pass (they're reliant on Ethereum 2.0.5)
### - How I did it
I did this by looking at what was broken and fixing it.
### - How to verify it
Check that travis is passing
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/31140791-c0c13b06-a832-11e7-8d1b-fae3062d5618.png)

