### PR TITLE
Add num256 to num casting (in function signature)

### DIFF
--- a/tests/parser/types/numbers/test_num256.py
+++ b/tests/parser/types/numbers/test_num256.py
@@ -81,11 +81,16 @@ def built_in_conversion(x: num256) -> num:
 
     c = get_contract(code)
     assert c._num256_to_num(1) == 1
-    assert c._num256_to_num((2**127)-1) == 2**127-1
+    assert c._num256_to_num((2**127) - 1) == 2**127 - 1
     t.s = s
-    assert_tx_failed(t, lambda: c._num256_to_num((2**127)) == 0, ValueOutOfBounds)
+    assert_tx_failed(t, lambda: c._num256_to_num((2**128)) == 0)
     assert c._num256_to_num_call(1) == 1
     # Make sure it has int128 overflow
     assert c._num256_to_num_call(2**127) == -170141183460469231731687303715884105728
     # Check that casting matches manual conversion
-    assert c._num256_to_num_call(2**127) == c.built_in_conversion(2**127)
+    assert c._num256_to_num_call(2**127 - 1) == c.built_in_conversion(2**127 - 1)
+
+    # Pass in negative int.
+    assert_tx_failed(t, lambda: c._num256_to_num(-1) != -1, ValueOutOfBounds)
+    # Ensure uint256 function signature.
+    assert c.translator.function_data['_num256_to_num']['encode_types'] == ['uint256']

--- a/tests/parser/types/numbers/test_num256.py
+++ b/tests/parser/types/numbers/test_num256.py
@@ -80,17 +80,20 @@ def built_in_conversion(x: num256) -> num:
     """
 
     c = get_contract(code)
+
+    # Ensure uint256 function signature.
+    assert c.translator.function_data['_num256_to_num']['encode_types'] == ['uint256']
+
     assert c._num256_to_num(1) == 1
     assert c._num256_to_num((2**127) - 1) == 2**127 - 1
     t.s = s
     assert_tx_failed(t, lambda: c._num256_to_num((2**128)) == 0)
     assert c._num256_to_num_call(1) == 1
-    # Make sure it has int128 overflow
-    assert c._num256_to_num_call(2**127) == -170141183460469231731687303715884105728
+
     # Check that casting matches manual conversion
     assert c._num256_to_num_call(2**127 - 1) == c.built_in_conversion(2**127 - 1)
 
     # Pass in negative int.
     assert_tx_failed(t, lambda: c._num256_to_num(-1) != -1, ValueOutOfBounds)
-    # Ensure uint256 function signature.
-    assert c.translator.function_data['_num256_to_num']['encode_types'] == ['uint256']
+    # Make sure it can't be coherced into a negative number.
+    assert_tx_failed(t, lambda: c._num256_to_num_call(2**127))

--- a/viper/function_signature.py
+++ b/viper/function_signature.py
@@ -67,6 +67,7 @@ class FunctionSignature():
                 pos += 32
             else:
                 pos += get_size_of_type(parsed_type) * 32
+
         # Apply decorators
         const, payable, internal = False, False, False
         for dec in code.decorator_list:

--- a/viper/parser.py
+++ b/viper/parser.py
@@ -230,10 +230,10 @@ def get_contracts_and_defs_and_globals(code):
 initializer_lll = LLLnode.from_list(['seq',
                                         ['mstore', 28, ['calldataload', 0]],
                                         ['mstore', ADDRSIZE_POS, 2**160],
-                                        ['mstore', MAXNUM_POS, 2**128 - 1],
-                                        ['mstore', MINNUM_POS, -2**128 + 1],
-                                        ['mstore', MAXDECIMAL_POS, (2**128 - 1) * DECIMAL_DIVISOR],
-                                        ['mstore', MINDECIMAL_POS, (-2**128 + 1) * DECIMAL_DIVISOR],
+                                        ['mstore', MAXNUM_POS, 2**127 - 1],
+                                        ['mstore', MINNUM_POS, -2**127],
+                                        ['mstore', MAXDECIMAL_POS, (2**127 - 1) * DECIMAL_DIVISOR],
+                                        ['mstore', MINDECIMAL_POS, (-2**127 + 1) * DECIMAL_DIVISOR],
                                     ], typ=None)
 
 

--- a/viper/parser.py
+++ b/viper/parser.py
@@ -233,7 +233,7 @@ initializer_lll = LLLnode.from_list(['seq',
                                         ['mstore', MAXNUM_POS, 2**127 - 1],
                                         ['mstore', MINNUM_POS, -2**127],
                                         ['mstore', MAXDECIMAL_POS, (2**127 - 1) * DECIMAL_DIVISOR],
-                                        ['mstore', MINDECIMAL_POS, (-2**127 + 1) * DECIMAL_DIVISOR],
+                                        ['mstore', MINDECIMAL_POS, (-2**127) * DECIMAL_DIVISOR],
                                     ], typ=None)
 
 

--- a/viper/parser_utils.py
+++ b/viper/parser_utils.py
@@ -408,6 +408,8 @@ def base_type_conversion(orig, frm, to):
         return LLLnode(orig.value, orig.args, typ=to)
     elif is_base_type(frm, 'num') and is_base_type(to, 'decimal') and are_units_compatible(frm, to):
         return LLLnode.from_list(['mul', orig, DECIMAL_DIVISOR], typ=BaseType('decimal', to.unit, to.positional))
+    elif is_base_type(frm, 'num256') and is_base_type(to, 'num') and are_units_compatible(frm, to):
+        return LLLnode.from_list(['clamp', 0, orig, ['mload', MAXNUM_POS]], typ=BaseType("num"))
     elif isinstance(frm, NullType):
         if to.typ not in ('num', 'bool', 'num256', 'address', 'bytes32', 'decimal'):
             raise TypeMismatchException("Cannot convert null-type object to type %r" % to)

--- a/viper/parser_utils.py
+++ b/viper/parser_utils.py
@@ -409,7 +409,7 @@ def base_type_conversion(orig, frm, to):
     elif is_base_type(frm, 'num') and is_base_type(to, 'decimal') and are_units_compatible(frm, to):
         return LLLnode.from_list(['mul', orig, DECIMAL_DIVISOR], typ=BaseType('decimal', to.unit, to.positional))
     elif is_base_type(frm, 'num256') and is_base_type(to, 'num') and are_units_compatible(frm, to):
-        return LLLnode.from_list(['clamp', 0, orig, ['mload', MAXNUM_POS]], typ=BaseType("num"))
+        return LLLnode.from_list(['uclample', orig, ['mload', MAXNUM_POS]], typ=BaseType("num"))
     elif isinstance(frm, NullType):
         if to.typ not in ('num', 'bool', 'num256', 'address', 'bytes32', 'decimal'):
             raise TypeMismatchException("Cannot convert null-type object to type %r" % to)

--- a/viper/types.py
+++ b/viper/types.py
@@ -254,6 +254,9 @@ def parse_type(item, location):
             argz = item.args
         if len(argz) != 1:
             raise InvalidTypeException("Malformed unit type", item)
+        # Check for num256 to num casting
+        if item.func.id == 'num' and item.args[0].id == 'num256':
+            return BaseType('num')
         unit = parse_unit(argz[0])
         return BaseType(base_type, unit, positional)
     # Subscripts


### PR DESCRIPTION
### - What I did

- Altered the max values that get stored in memory for clamps to compare against.
- Added support for num(num256) function signatures.

### - How I did it

- Edited base_type_conversion (Thanks @DavidKnott !)
- Applied changes in BaseType and canonicalize_type to generate the appropriate ABI signature.

### - How to verify it

Check tests and play with function using the `num(num256)` signature:

```
def _num256_to_num(x: num(num256)) -> num:
    return x
```

### - Description for the changelog
Added support for num(num256) function signatures.

### - Cute Animal Picture

![](https://i.pinimg.com/736x/65/ca/94/65ca949c0640908bb2be5440681af901--baby-animals-funny-animals.jpg)