### PR TITLE
Don't use fancy quotes

### DIFF
--- a/docs/installing-viper.rst
+++ b/docs/installing-viper.rst
@@ -91,8 +91,8 @@ install and test commands
 
     Use the following commands:
     ::
-        export CFLAGS=“-I$(brew --prefix openssl)/include”
-        export LDFLAGS=“-L$(brew --prefix openssl)/lib”
+        export CFLAGS="-I$(brew --prefix openssl)/include"
+        export LDFLAGS="-L$(brew --prefix openssl)/lib"
         pip install scrypt
 
     Now you can run the install and test commands again:

--- a/docs/old_readme.txt
+++ b/docs/old_readme.txt
@@ -261,7 +261,7 @@ python setup.py test
 
 If it fails with some error message on `openssl`, do the following:
 ```
-env LDFLAGS=“-L$(brew --prefix openssl)/lib” CFLAGS=“-I$(brew --prefix openssl)/include” pip install scrypt
+env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install scrypt
 ```
 
 # Compile 


### PR DESCRIPTION
### - What I did

Changed fancy quotes to normal quotes. If you copy paste, it will just export the variable with fancy quotes... and you won't know why `scrypt` is failing to install on Mac.

### - How I did it

`grep -r "”" . -l`

### - How to verify it

Just check... also if you're developing on a Mac, disable this by default under `Preferences > Keyboard > Text`. 

### - Description for the changelog

- Replaced fancy quotes with normal quotes in the installation documentation.

### - Cute Animal Picture

<img src="https://media.giphy.com/media/xNPB9OnYtIGzK/giphy.gif"/>
