### PR TITLE
Add is_contract address attribute

### DIFF
--- a/tests/parser/functions/test_is_contract.py
+++ b/tests/parser/functions/test_is_contract.py
@@ -1,0 +1,27 @@
+import pytest
+from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
+    get_contract_with_gas_estimation, get_contract
+
+
+def test_is_contract():
+    contract_1 = """
+def foo(arg1: address) -> bool:
+    result = arg1.is_contract
+    return result
+"""
+
+    contract_2 = """
+def foo(arg1: address) -> bool:
+    return arg1.is_contract
+"""
+    c1 = get_contract(contract_1)
+    c2 = get_contract(contract_2)
+    
+    assert c1.foo(c1.address) == True
+    assert c1.foo(c2.address) == True
+    assert c1.foo(t.a1) == False
+    assert c1.foo(t.a3) == False
+    assert c2.foo(c1.address) == True
+    assert c2.foo(c2.address) == True
+    assert c2.foo(t.a1) == False
+    assert c2.foo(t.a3) == False

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -567,11 +567,15 @@ def parse_expr(expr, context):
                 raise TypeMismatchException("Type mismatch: balance keyword expects an address as input", expr)
             return LLLnode.from_list(['balance', addr], typ=BaseType('num', {'wei': 1}), location=None, pos=getpos(expr))
         # x.codesize: codesize of address x
-        elif expr.attr == 'codesize':
+        elif expr.attr == 'codesize' or expr.attr == 'is_contract':
             addr = parse_value_expr(expr.value, context)
             if not is_base_type(addr.typ, 'address'):
-                raise TypeMismatchException("Type mismatch: codesize keyword expects an address as input", expr)
-            return LLLnode.from_list(['extcodesize', addr], typ=BaseType('num'), location=None, pos=getpos(expr))
+                raise TypeMismatchException(f"Type mismatch: {expr.attr} keyword expects an address as input", expr)
+            if expr.attr == 'codesize':
+                output_type = 'num'
+            else:
+                output_type = 'bool'
+            return LLLnode.from_list(['extcodesize', addr], typ=BaseType(output_type), location=None, pos=getpos(expr))
         # self.x: global attribute
         elif isinstance(expr.value, ast.Name) and expr.value.id == "self":
             if expr.attr not in context.globals:


### PR DESCRIPTION
### - What I did
Added `is_contract` attribute to addresses which returns a bool telling wether the given address is a contract or not.  In response to #365.
### - How I did it
I expanded upon the existing `codesize` address function.
### - How to verify it
Look at my pr / try using it in your code.
### - Description for the changelog
Add is_contract
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/31311546-c2dd0fe6-ab6b-11e7-90d4-f160911298d5.png)

