### PR TITLE
Added safe remote purchase example

### DIFF
--- a/examples/safe_remote_purchase/safe_remote_purchase.v.py
+++ b/examples/safe_remote_purchase/safe_remote_purchase.v.py
@@ -1,0 +1,38 @@
+#Safe Remote Purchase (https://github.com/ethereum/solidity/blob/develop/docs/solidity-by-example.rst) ported to viper and optimized
+
+#Rundown of the transaction:
+#1. Seller posts item for sale and posts safety deposit of double the item value. Balance is 2*value.
+#(1.1. Seller can reclaim deposit and close the sale as long as nothing was purchased.)
+#2. Buyer purchases item (value) plus posts an additional safety deposit (Item value). Balance is 4*value
+#3. Seller ships item
+#4. Buyer confirms receiving the item. Buyer's deposit (value) is returned. Seller's deposit (2*value) + items value is returned. Balance is 0.
+
+value: public(wei_value) #Value of the item
+seller: public(address)
+buyer: public(address)
+
+@constant
+def unlocked() -> bool: #Is a refund possible for the seller?
+    return (self.balance == self.value*2)
+    
+@payable
+def __init__():
+    self.value = msg.value / 2 #Seller initializes contract by posting a safety deposit of 2*value of the item up for sale
+    self.seller = msg.sender
+    
+def abort():
+    assert self.unlocked() == true #Is the contract still refundable
+    assert msg.sender == self.seller #Only seller can refund his deposit before any buyer purchases the item
+    selfdestruct(self.seller) #Refunds seller, deletes contract
+
+@payable
+def purchase():
+    assert self.unlocked() == true #Contract still open (item still up for sale)?
+    assert msg.value == (2*self.value) #Is the deposit of correct value?
+    self.buyer = msg.sender
+    
+def recieved():
+    assert self.unlocked() == false #Is the item already purchased and pending confirmation of buyer
+    assert msg.sender == self.buyer 
+    send(self.buyer, self.value) #Return deposit (=value) to buyer
+selfdestruct(self.seller) #Returns deposit (=2*value) and the purchase price (=value)

--- a/examples/safe_remote_purchase/safe_remote_purchase.v.py
+++ b/examples/safe_remote_purchase/safe_remote_purchase.v.py
@@ -17,22 +17,23 @@ def unlocked() -> bool: #Is a refund possible for the seller?
     
 @payable
 def __init__():
+    assert (msg.value % 2) == 0
     self.value = msg.value / 2 #Seller initializes contract by posting a safety deposit of 2*value of the item up for sale
     self.seller = msg.sender
     
 def abort():
-    assert self.unlocked() == true #Is the contract still refundable
+    assert self.unlocked() #Is the contract still refundable
     assert msg.sender == self.seller #Only seller can refund his deposit before any buyer purchases the item
     selfdestruct(self.seller) #Refunds seller, deletes contract
 
 @payable
 def purchase():
-    assert self.unlocked() == true #Contract still open (item still up for sale)?
+    assert self.unlocked() #Contract still open (item still up for sale)?
     assert msg.value == (2*self.value) #Is the deposit of correct value?
     self.buyer = msg.sender
     
 def recieved():
-    assert self.unlocked() == false #Is the item already purchased and pending confirmation of buyer
+    assert not self.unlocked() #Is the item already purchased and pending confirmation of buyer
     assert msg.sender == self.buyer 
     send(self.buyer, self.value) #Return deposit (=value) to buyer
-selfdestruct(self.seller) #Returns deposit (=2*value) and the purchase price (=value)
+    selfdestruct(self.seller) #Returns deposit (=2*value) and the purchase price (=value)

--- a/examples/safe_remote_purchase/safe_remote_purchase.v.py
+++ b/examples/safe_remote_purchase/safe_remote_purchase.v.py
@@ -10,30 +10,32 @@
 value: public(wei_value) #Value of the item
 seller: public(address)
 buyer: public(address)
-
-@constant
-def unlocked() -> bool: #Is a refund possible for the seller?
-    return (self.balance == self.value*2)
-    
+unlocked: public(bool)
+#@constant
+#def unlocked() -> bool: #Is a refund possible for the seller?
+#    return (self.balance == self.value*2)
+#    
 @payable
 def __init__():
     assert (msg.value % 2) == 0
     self.value = msg.value / 2 #Seller initializes contract by posting a safety deposit of 2*value of the item up for sale
     self.seller = msg.sender
+    self.unlocked = true
     
 def abort():
-    assert self.unlocked() #Is the contract still refundable
+    assert self.unlocked #Is the contract still refundable
     assert msg.sender == self.seller #Only seller can refund his deposit before any buyer purchases the item
     selfdestruct(self.seller) #Refunds seller, deletes contract
 
 @payable
 def purchase():
-    assert self.unlocked() #Contract still open (item still up for sale)?
+    assert self.unlocked #Contract still open (item still up for sale)?
     assert msg.value == (2*self.value) #Is the deposit of correct value?
     self.buyer = msg.sender
+    self.unlocked = false
     
-def recieved():
-    assert not self.unlocked() #Is the item already purchased and pending confirmation of buyer
+def received():
+    assert not self.unlocked #Is the item already purchased and pending confirmation of buyer
     assert msg.sender == self.buyer 
     send(self.buyer, self.value) #Return deposit (=value) to buyer
     selfdestruct(self.seller) #Returns deposit (=2*value) and the purchase price (=value)

--- a/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
+++ b/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
@@ -9,28 +9,29 @@
 import pytest
 from ethereum.tools import tester 
 from ethereum import utils
+from tests.setup_transaction_tests import assert_tx_failed
 
 contract_code = open("examples/safe_remote_purchase/safe_remote_purchase.v.py").read()
+#Inital balance of accounts
+INIT_BAL = 1000000000000000000000000
+
 @pytest.fixture
 def srp_tester():
     t = tester
     tester.s = t.Chain()
     from viper import compiler
     t.languages["viper"] = compiler.Compiler()
-    #tester.c = tester.s.contract(contract_code, language = "viper", args = [], value=10)
     return tester
 
 @pytest.fixture
-
-def assert_tx_failed():
-    def assert_tx_failed(tester, function_to_test, exception = tester.TransactionFailed):
-        initial_state = tester.s.snapshot()
-        with pytest.raises(exception):
-            function_to_test()
-        tester.s.revert(initial_state)
-    return assert_tx_failed
+def check_balance(tester):
+    #balance of a0 = seller, a1 = buyer 
+    sbal = tester.s.head_state.get_balance(tester.a0) 
+    bbal = tester.s.head_state.get_balance(tester.a1)
+    return [sbal, bbal]
 
 def test_initial_state(srp_tester, assert_tx_failed):
+    assert check_balance(srp_tester) == [INIT_BAL, INIT_BAL]
     #Inital deposit has to be divisible by two
     assert_tx_failed(srp_tester, lambda: srp_tester.s.contract(contract_code, language = "viper", args = [], value = 1))
     #Seller puts item up for sale
@@ -40,25 +41,47 @@ def test_initial_state(srp_tester, assert_tx_failed):
     #Check if item value is set correctly (Half of deposit)
     assert srp_tester.c.get_value() == 1
     #Check if unlocked() works correctly after initialization
-    assert srp_tester.c.unlocked() == True
-"""
-def test_abort(srp_tester):
+    assert srp_tester.c.get_unlocked() == True
+    #Check that sellers (and buyers) balance is correct
+    assert check_balance(srp_tester) == [INIT_BAL-2, INIT_BAL]
+
+def test_abort(srp_tester, assert_tx_failed):
+    srp_tester.c = srp_tester.s.contract(contract_code, language = "viper", args = [], value=2)
+    #Only sender can trigger refund
+    assert_tx_failed(srp_tester, lambda: srp_tester.c.abort(sender=srp_tester.k2))
+    #Refund works correctly
+    srp_tester.c.abort(sender=srp_tester.k0)
+    assert check_balance(srp_tester) == [INIT_BAL, INIT_BAL]
+    #Purchase in process, no refund possible
+    srp_tester.c = srp_tester.s.contract(contract_code, language = "viper", args = [], value=2)
+    srp_tester.c.purchase(value=2, sender=srp_tester.k1)
+    assert_tx_failed(srp_tester, lambda: srp_tester.c.abort(sender=srp_tester.k0))
     
-    #Check if unlocked
-    assert 
-    """
 def test_purchase(srp_tester, assert_tx_failed):
     srp_tester.c = srp_tester.s.contract(contract_code, language = "viper", args = [], value=2)
-    print(srp_tester.c.get_value())
-    print(srp_tester.c.unlocked())
     #Purchase for too low/high price
-    assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=1, sender=srp_tester.k2))
-    assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=3, sender=srp_tester.k2))
+    assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=1, sender=srp_tester.k1))
+    assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=3, sender=srp_tester.k1))
     #Purchase for the correct price 
-    srp_tester.c.purchase(value=2, sender=srp_tester.k2)
+    srp_tester.c.purchase(value=2, sender=srp_tester.k1)
     #Check if buyer is set correctly
     assert utils.remove_0x_head(srp_tester.c.get_buyer()) == srp_tester.accounts[1].hex()
     #Check if contract is locked correctly
-    assert srp_tester.c.unlocked() == false
+    assert srp_tester.c.get_unlocked() == False
+    #Check balances, both deposits should have been deducted
+    assert check_balance(srp_tester) == [INIT_BAL-2, INIT_BAL-2]
     #Allow nobody else to purchase
     assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=2, sender=srp_tester.k3))
+
+def test_received(srp_tester, assert_tx_failed):
+    srp_tester.c = srp_tester.s.contract(contract_code, language = "viper", args = [], value=2)
+    #Can only be called after purchase
+    assert_tx_failed(srp_tester, lambda: srp_tester.c.received(sender=srp_tester.k1))
+    #Purchase completed
+    srp_tester.c.purchase(value=2, sender=srp_tester.k1)
+    #Check that e.g. sender cannot trigger received
+    assert_tx_failed(srp_tester, lambda: srp_tester.c.received(sender=srp_tester.k0))
+    #Check if buyer can call receive
+    srp_tester.c.received(sender=srp_tester.k1)
+    #Final check if everything worked. 1 value has been transferred
+    assert check_balance(srp_tester) == [INIT_BAL+1, INIT_BAL-1]

--- a/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
+++ b/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
@@ -1,0 +1,64 @@
+#Test for Safe Remote Purchase (https://github.com/ethereum/solidity/blob/develop/docs/solidity-by-example.rst) ported to viper and optimized
+
+#Rundown of the transaction:
+#1. Seller posts item for sale and posts safety deposit of double the item value. Balance is 2*value.
+#(1.1. Seller can reclaim deposit and close the sale as long as nothing was purchased.)
+#2. Buyer purchases item (value) plus posts an additional safety deposit (Item value). Balance is 4*value
+#3. Seller ships item
+#4. Buyer confirms receiving the item. Buyer's deposit (value) is returned. Seller's deposit (2*value) + items value is returned. Balance is 0.
+import pytest
+from ethereum.tools import tester 
+from ethereum import utils
+
+contract_code = open("examples/safe_remote_purchase/safe_remote_purchase.v.py").read()
+@pytest.fixture
+def srp_tester():
+    t = tester
+    tester.s = t.Chain()
+    from viper import compiler
+    t.languages["viper"] = compiler.Compiler()
+    #tester.c = tester.s.contract(contract_code, language = "viper", args = [], value=10)
+    return tester
+
+@pytest.fixture
+
+def assert_tx_failed():
+    def assert_tx_failed(tester, function_to_test, exception = tester.TransactionFailed):
+        initial_state = tester.s.snapshot()
+        with pytest.raises(exception):
+            function_to_test()
+        tester.s.revert(initial_state)
+    return assert_tx_failed
+
+def test_initial_state(srp_tester, assert_tx_failed):
+    #Inital deposit has to be divisible by two
+    assert_tx_failed(srp_tester, lambda: srp_tester.s.contract(contract_code, language = "viper", args = [], value = 1))
+    #Seller puts item up for sale
+    srp_tester.c = tester.s.contract(contract_code, language = "viper", args = [], value=2)
+    #Check that the seller is set correctly
+    assert utils.remove_0x_head(srp_tester.c.get_seller()) == srp_tester.accounts[0].hex()
+    #Check if item value is set correctly (Half of deposit)
+    assert srp_tester.c.get_value() == 1
+    #Check if unlocked() works correctly after initialization
+    assert srp_tester.c.unlocked() == True
+"""
+def test_abort(srp_tester):
+    
+    #Check if unlocked
+    assert 
+    """
+def test_purchase(srp_tester, assert_tx_failed):
+    srp_tester.c = srp_tester.s.contract(contract_code, language = "viper", args = [], value=2)
+    print(srp_tester.c.get_value())
+    print(srp_tester.c.unlocked())
+    #Purchase for too low/high price
+    assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=1, sender=srp_tester.k2))
+    assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=3, sender=srp_tester.k2))
+    #Purchase for the correct price 
+    srp_tester.c.purchase(value=2, sender=srp_tester.k2)
+    #Check if buyer is set correctly
+    assert utils.remove_0x_head(srp_tester.c.get_buyer()) == srp_tester.accounts[1].hex()
+    #Check if contract is locked correctly
+    assert srp_tester.c.unlocked() == false
+    #Allow nobody else to purchase
+    assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=2, sender=srp_tester.k3))


### PR DESCRIPTION
### - What I did
Implemented and cleaned up the "Safe remote purchase" from the Solidity documentation (https://solidity.readthedocs.io/en/develop/solidity-by-example.html#safe-remote-purchase)
Edit: Fixed missing spaces in last line.
### - How I did it
Translated the code from Solidity to Viper.
Differences:
- Used selfdestruct() where applicable
- ~~Locked state is determined by the contract balance~~ Didn't pass tests and could be exploited.
- Comments explaining transaction details added
- Value does not need to be a multiple of two

### - How to verify it
Auditing code. Test cases could be implemented.

### - Description for the changelog
Added "Safe remote purchase" example

### - Cute Animal Picture
![gorilla](https://c1.staticflickr.com/2/1663/25169527263_c28a2a48f2_b.jpg)
