### PR TITLE
Add overflow protection to num256 functions

### DIFF
--- a/tests/parser/types/numbers/test_num256.py
+++ b/tests/parser/types/numbers/test_num256.py
@@ -62,15 +62,47 @@ def _num256_le(x: num256, y: num256) -> bool:
 
     print("Passed num256 operation tests")
 
-def test_num256_with_exponents():
+
+def test_num256_mod(assert_tx_failed):
+    num256_code = """
+def _num256_mod(x: num256, y: num256) -> num256:
+    return num256_mod(x, y)
+
+def _num256_addmod(x: num256, y: num256, z: num256) -> num256:
+    return num256_addmod(x, y, z)
+
+def _num256_mulmod(x: num256, y: num256, z: num256) -> num256:
+    return num256_mulmod(x, y, z)
+    """
+
+    c = get_contract(num256_code)
+    t.s = s
+
+    assert c._num256_mod(3, 2) == 1
+    assert c._num256_mod(34, 32) == 2
+    assert c._num256_addmod(1, 2, 2) == 1
+    assert c._num256_addmod(32, 2, 32) == 2
+    assert c._num256_addmod((2**256) - 1, 0, 2) == 1
+    assert_tx_failed(t, lambda: c._num256_addmod((2**256) - 1, 1, 1))
+    assert c._num256_mulmod(3, 1, 2) == 1
+    assert c._num256_mulmod(200, 3, 601) == 600
+    assert c._num256_mulmod(2**255, 1, 3) == 2
+    assert_tx_failed(t, lambda: c._num256_mulmod(2**255, 2, 1))
+
+
+def test_num256_with_exponents(assert_tx_failed):
     exp_code = """
 def _num256_exp(x: num256, y: num256) -> num256:
         return num256_exp(x,y)
     """
 
     c = get_contract(exp_code)
+    t.s = s
+
+    assert c._num256_exp(2, 0) == 1
+    assert c._num256_exp(2, 1) == 2
     assert c._num256_exp(2, 3) == 8
-    assert c._num256_exp(2**128, 2) == 0
+    assert_tx_failed(t, lambda: c._num256_exp(2**128, 2))
     assert c._num256_exp(2**64, 2) == 2**128
     assert c._num256_exp(7**23, 3) == 7**69
 

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -655,19 +655,23 @@ def bitwise_xor(expr, args, kwargs, context):
 
 @signature('num256', 'num256')
 def num256_add(expr, args, kwargs, context):
-    return LLLnode.from_list(['seq', ['assert', ['or', ['iszero', args[1]], ['gt', ['add', args[0], args[1]], args[0]]]],
-                            ['add', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
+    return LLLnode.from_list(['seq',
+                                ['assert', ['or', ['iszero', args[1]], ['gt', ['add', args[0], args[1]], args[0]]]],
+                                ['add', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256', 'num256')
 def num256_sub(expr, args, kwargs, context):
-    return LLLnode.from_list(['seq', ['assert', ['or', ['iszero', args[1]], ['lt', ['sub', args[0], args[1]], args[0]]]],
-                            ['sub', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
+    return LLLnode.from_list(['seq',
+                                ['assert', ['or', ['iszero', args[1]], ['lt', ['sub', args[0], args[1]], args[0]]]],
+                                ['sub', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256', 'num256')
 def num256_mul(expr, args, kwargs, context):
-    return LLLnode.from_list(['seq', ['assert', ['or', ['iszero', args[0]], ['eq', ['div', ['mul', args[0], args[1]], args[0]], args[1]]]],
+    return LLLnode.from_list(['seq',
+                                ['assert', ['or', ['iszero', args[0]],
+                                ['eq', ['div', ['mul', args[0], args[1]], args[0]], args[1]]]],
                                 ['mul', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
@@ -679,7 +683,10 @@ def num256_div(expr, args, kwargs, context):
 
 @signature('num256', 'num256')
 def num256_exp(expr, args, kwargs, context):
-    return LLLnode.from_list(['exp', args[0], args[1]], typ=BaseType('num256'), pos=getpos(expr))
+    return LLLnode.from_list(['seq',
+                                ['assert', ['or', ['or', ['eq', args[1], 1], ['iszero', args[1]]],
+                                ['lt', args[0], ['exp', args[0], args[1]]]]],
+                                ['exp', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256', 'num256')
@@ -689,12 +696,17 @@ def num256_mod(expr, args, kwargs, context):
 
 @signature('num256', 'num256', 'num256')
 def num256_addmod(expr, args, kwargs, context):
-    return LLLnode.from_list(['addmod', args[0], args[1], args[2]], typ=BaseType('num256'), pos=getpos(expr))
+    return LLLnode.from_list(['seq',
+                                ['assert', ['or', ['iszero', args[1]], ['gt', ['add', args[0], args[1]], args[0]]]],
+                                ['addmod', args[0], args[1], args[2]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256', 'num256', 'num256')
 def num256_mulmod(expr, args, kwargs, context):
-    return LLLnode.from_list(['mulmod', args[0], args[1], args[2]], typ=BaseType('num256'), pos=getpos(expr))
+    return LLLnode.from_list(['seq',
+                                ['assert', ['or', ['iszero', args[0]],
+                                ['eq', ['div', ['mul', args[0], args[1]], args[0]], args[1]]]],
+                                ['mulmod', args[0], args[1], args[2]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256')

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -656,6 +656,7 @@ def bitwise_xor(expr, args, kwargs, context):
 @signature('num256', 'num256')
 def num256_add(expr, args, kwargs, context):
     return LLLnode.from_list(['seq',
+                                # Checks that: a + b > a
                                 ['assert', ['or', ['iszero', args[1]], ['gt', ['add', args[0], args[1]], args[0]]]],
                                 ['add', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
@@ -663,13 +664,15 @@ def num256_add(expr, args, kwargs, context):
 @signature('num256', 'num256')
 def num256_sub(expr, args, kwargs, context):
     return LLLnode.from_list(['seq',
-                                ['assert', ['or', ['iszero', args[1]], ['lt', ['sub', args[0], args[1]], args[0]]]],
+                                # Checks that: a >= b
+                                ['assert', ['or', ['iszero', args[1]], ['sge', args[0], args[1]]]],
                                 ['sub', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256', 'num256')
 def num256_mul(expr, args, kwargs, context):
     return LLLnode.from_list(['seq',
+                                # Checks that: a == 0 || a / b == b
                                 ['assert', ['or', ['iszero', args[0]],
                                 ['eq', ['div', ['mul', args[0], args[1]], args[0]], args[1]]]],
                                 ['mul', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
@@ -677,7 +680,9 @@ def num256_mul(expr, args, kwargs, context):
 
 @signature('num256', 'num256')
 def num256_div(expr, args, kwargs, context):
-    return LLLnode.from_list(['seq', ['assert', args[1]],
+    return LLLnode.from_list(['seq',
+                                # Checks that:  b != 0
+                                ['assert', args[1]],
                                 ['div', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -655,22 +655,26 @@ def bitwise_xor(expr, args, kwargs, context):
 
 @signature('num256', 'num256')
 def num256_add(expr, args, kwargs, context):
-    return LLLnode.from_list(['add', args[0], args[1]], typ=BaseType('num256'), pos=getpos(expr))
+    return LLLnode.from_list(['seq', ['assert', ['or', ['iszero', args[1]], ['gt', ['add', args[0], args[1]], args[0]]]],
+                            ['add', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256', 'num256')
 def num256_sub(expr, args, kwargs, context):
-    return LLLnode.from_list(['sub', args[0], args[1]], typ=BaseType('num256'), pos=getpos(expr))
+    return LLLnode.from_list(['seq', ['assert', ['or', ['iszero', args[1]], ['lt', ['sub', args[0], args[1]], args[0]]]],
+                            ['sub', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256', 'num256')
 def num256_mul(expr, args, kwargs, context):
-    return LLLnode.from_list(['mul', args[0], args[1]], typ=BaseType('num256'), pos=getpos(expr))
+    return LLLnode.from_list(['seq', ['assert', ['or', ['iszero', args[0]], ['eq', ['div', ['mul', args[0], args[1]], args[0]], args[1]]]],
+                                ['mul', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256', 'num256')
 def num256_div(expr, args, kwargs, context):
-    return LLLnode.from_list(['div', args[0], args[1]], typ=BaseType('num256'), pos=getpos(expr))
+    return LLLnode.from_list(['seq', ['assert', args[1]],
+                                ['div', args[0], args[1]]], typ=BaseType('num256'), pos=getpos(expr))
 
 
 @signature('num256', 'num256')


### PR DESCRIPTION
### - What I did
Added overflow protection to `num256` functions.
### - How I did it
I did this by looking at Solidity's `SafeMath.sol` and writing it in `LLL`.
### - How to verify it
Look at the tests I added, especially the ones that fail because of overflow.
### - Description for the changelog
Add num256 overflow protection
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/31314234-cdb9441e-abb8-11e7-8fab-e7ec8d1f0e21.png)

