### PR TITLE
External contract calls cannot be used internally

### DIFF
--- a/tests/parser/features/test_external_contract_calls.py
+++ b/tests/parser/features/test_external_contract_calls.py
@@ -199,6 +199,34 @@ def __init__(arg1: address):
     print('Successfully executed a multiple external contract calls')
 
 
+def test_invalid_external_contract_call_to_the_same_contract(assert_tx_failed):
+    contract_1 = """
+def bar() -> num:
+    return 1
+    """
+    contract_2 = """
+class Bar():
+    def bar() -> num: pass
+
+def bar() -> num:
+    return 1
+
+def _stmt(x: address):
+    Bar(x).bar()
+
+def _expr(x: address) -> num:
+    return Bar(x).bar()
+    """
+    t.s = t.Chain()
+
+    c1 = get_contract(contract_1)
+    c2 = get_contract(contract_2)
+    c2._stmt(c1.address)
+    c2._expr(c1.address)
+    assert_tx_failed(t, lambda: c2._stmt(c2.address))
+    assert_tx_failed(t, lambda: c2._expr(c2.address))
+
+
 def test_invalid_contract_reference_declaration(assert_tx_failed):
     contract = """
 class Bar():

--- a/tests/parser/features/test_external_contract_calls.py
+++ b/tests/parser/features/test_external_contract_calls.py
@@ -204,6 +204,7 @@ def test_invalid_external_contract_call_to_the_same_contract(assert_tx_failed):
 def bar() -> num:
     return 1
     """
+
     contract_2 = """
 class Bar():
     def bar() -> num: pass
@@ -217,14 +218,38 @@ def _stmt(x: address):
 def _expr(x: address) -> num:
     return Bar(x).bar()
     """
-    t.s = t.Chain()
 
+    t.s = t.Chain()
     c1 = get_contract(contract_1)
     c2 = get_contract(contract_2)
+
     c2._stmt(c1.address)
     c2._expr(c1.address)
     assert_tx_failed(t, lambda: c2._stmt(c2.address))
     assert_tx_failed(t, lambda: c2._expr(c2.address))
+
+
+def test_invalid_nonexistent_contract_call(assert_tx_failed):
+    contract_1 = """
+def bar() -> num:
+    return 1
+    """
+
+    contract_2 = """
+class Bar():
+    def bar() -> num: pass
+
+def foo(x: address) -> num:
+    return Bar(x).bar()
+    """
+
+    c1 = get_contract(contract_1)
+    c2 = get_contract(contract_2)
+    t.s = s
+
+    assert c2.foo(c1.address) == 1
+    assert_tx_failed(t, lambda: c2.foo(t.a1))
+    assert_tx_failed(t, lambda: c2.foo(t.a7))
 
 
 def test_invalid_contract_reference_declaration(assert_tx_failed):

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -460,7 +460,9 @@ def external_contract_call_stmt(stmt, context):
     sig = context.sigs[contract_name][method_name]
     contract_address = parse_expr(stmt.func.value.args[0], context)
     inargs, inargsize = pack_arguments(sig, [parse_expr(arg, context) for arg in stmt.args], context)
-    o = LLLnode.from_list(['assert', ['call', ['gas'], ['mload', contract_address], 0, inargs, inargsize, 0, 0]],
+    o = LLLnode.from_list(['seq',
+                            ['assert', ['ne', 'address', ['mload', contract_address]]],
+                            ['assert', ['call', ['gas'], ['mload', contract_address], 0, inargs, inargsize, 0, 0]]],
                                     typ=None, location='memory', pos=getpos(stmt))
     return o
 
@@ -484,6 +486,7 @@ def external_contract_call_expr(expr, context):
     else:
         raise TypeMismatchException("Invalid output type: %r" % sig.output_type, expr)
     o = LLLnode.from_list(['seq',
+                            ['assert', ['ne', 'address', ['mload', contract_address]]],
                             ['assert', ['call', ['gas'], ['mload', contract_address], 0,
                             inargs, inargsize,
                             output_placeholder, get_size_of_type(sig.output_type) * 32]],

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -461,6 +461,7 @@ def external_contract_call_stmt(stmt, context):
     contract_address = parse_expr(stmt.func.value.args[0], context)
     inargs, inargsize = pack_arguments(sig, [parse_expr(arg, context) for arg in stmt.args], context)
     o = LLLnode.from_list(['seq',
+                            ['assert', ['extcodesize', ['mload', contract_address]]],
                             ['assert', ['ne', 'address', ['mload', contract_address]]],
                             ['assert', ['call', ['gas'], ['mload', contract_address], 0, inargs, inargsize, 0, 0]]],
                                     typ=None, location='memory', pos=getpos(stmt))
@@ -486,6 +487,7 @@ def external_contract_call_expr(expr, context):
     else:
         raise TypeMismatchException("Invalid output type: %r" % sig.output_type, expr)
     o = LLLnode.from_list(['seq',
+                            ['assert', ['extcodesize', ['mload', contract_address]]],
                             ['assert', ['ne', 'address', ['mload', contract_address]]],
                             ['assert', ['call', ['gas'], ['mload', contract_address], 0,
                             inargs, inargsize,


### PR DESCRIPTION
### - What I did
I added a check to external contract calls so that they can't be used internally.

### - How I did it
I did this by checking that the `external_address != current_address`.

### - How to verify it
Look at the test I wrote.
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/31314416-5fc5c09a-abbd-11e7-9249-3c9cf28e0036.png)

