### PR TITLE
Fix file pathing to parser.py

### DIFF
--- a/bin/viper
+++ b/bin/viper
@@ -5,7 +5,7 @@ import json
 import viper
 
 from viper import compiler, optimizer
-from viper.parser import parse_to_lll
+from viper.parser.parser import parse_to_lll
 
 parser = argparse.ArgumentParser(description='Viper {0} programming language for Ethereum'.format(viper.__version__))
 parser.add_argument('input_file', help='Viper sourcecode to compile')

--- a/bin/viper-serve
+++ b/bin/viper-serve
@@ -9,7 +9,7 @@ from socketserver import ThreadingMixIn
 
 import viper
 
-from viper.parser import parse_to_lll
+from viper.parser.parser import parse_to_lll
 from viper import compiler, optimizer
 
 


### PR DESCRIPTION
### - What I did
Fix fails paths so that `viper` and `viper-serv` commands work.
### - How I did it
I did this by looking at where `parser.py` was located.
### - How to verify it
Look at my PR
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/31319412-40de7dee-ac20-11e7-8d84-599c34857b16.png)

