### PR TITLE
Fix parse_to_lll import path.

### DIFF
--- a/bin/viper
+++ b/bin/viper
@@ -5,7 +5,7 @@ import json
 import viper
 
 from viper import compiler, optimizer
-from viper.parser import parse_to_lll
+from viper.parser.parser import parse_to_lll
 
 parser = argparse.ArgumentParser(description='Viper {0} programming language for Ethereum'.format(viper.__version__))
 parser.add_argument('input_file', help='Viper sourcecode to compile')

--- a/bin/viper-serve
+++ b/bin/viper-serve
@@ -9,7 +9,7 @@ from socketserver import ThreadingMixIn
 
 import viper
 
-from viper.parser import parse_to_lll
+from viper.parser.parser import parse_to_lll
 from viper import compiler, optimizer
 
 


### PR DESCRIPTION
### - What I did

bin/viper needed the full path to find the parse_to_lll function, I think this happened after the parser.py refactoring.

### - How I did it

### - How to verify it
Install and run viper.

### - Description for the changelog
N/A

### - Cute Animal Picture

![](https://pbs.twimg.com/profile_images/672096925487771648/PXYUbcf2.jpg)