### PR TITLE
Upgraded the required version of pyethereum to 2.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license=license,
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=[
-        'ethereum==2.0.5',
+        'ethereum==2.1.0',
         'bumpversion',
         'pytest-cov',
         'pytest-runner', # Must be after pytest-cov or it will not work


### PR DESCRIPTION
### - What I did
Upgraded the required version of `pyethereum` from `2.0.5` to `2.1.0`.

### - How I did it
Simply updated `setup.py`

### - How to verify it
Passed CI

### - Description for the changelog
None

### - Cute Animal Picture

![viper](https://user-images.githubusercontent.com/9263930/31508946-4fe2b512-af45-11e7-8183-6d73014d81d4.jpg)
