### PR TITLE
Add staticcall opcode for constant external function calls

### DIFF
--- a/tests/examples/company/test_company.py
+++ b/tests/examples/company/test_company.py
@@ -2,8 +2,9 @@ import pytest
 
 from ethereum.tools import tester as t
 from ethereum import utils
-from viper import compiler
+
 from tests.setup_transaction_tests import assert_tx_failed
+from viper import compiler
 
 @pytest.fixture
 def tester():

--- a/tests/parser/features/test_external_contract_calls.py
+++ b/tests/parser/features/test_external_contract_calls.py
@@ -101,12 +101,13 @@ def set_lucky(arg1: address, arg2: num):
     print('Successfully executed an external contract call state change')
 
 
-def test_constant_external_contract_call_cannot_change_state():
+def test_constant_external_contract_call_cannot_change_state(assert_tx_failed):
     contract_1 = """
 lucky: public(num)
 
-def set_lucky(_lucky: num):
+def set_lucky(_lucky: num) -> num:
     self.lucky = _lucky
+    return _lucky
     """
 
     lucky_number = 7
@@ -117,15 +118,18 @@ class Foo():
     def set_lucky(_lucky: num) -> num: pass
 
 @constant
-def set_lucky(arg1: address, arg2: num):
+def set_lucky_expr(arg1: address, arg2: num):
     Foo(arg1).set_lucky(arg2)
+
+@constant
+def set_lucky_stmt(arg1: address, arg2: num) -> num:
+    return Foo(arg1).set_lucky(arg2)
     """
     c2 = get_contract(contract_2)
 
-    assert c.get_lucky() == 0
-    c2.set_lucky(c.address, lucky_number)
-    assert c.get_lucky() == 0
-    print('Successfully executed an external contract call state change')
+    assert_tx_failed(lambda: c2.set_lucky_expr(c.address, lucky_number))
+    assert_tx_failed(lambda: c2.set_lucky_stmt(c.address, lucky_number))
+    print('Successfully tested an constant external contract call attempted state change')
 
 
 def test_external_contract_can_be_changed_based_on_address():

--- a/tests/parser/features/test_external_contract_calls.py
+++ b/tests/parser/features/test_external_contract_calls.py
@@ -75,7 +75,7 @@ def get_array(arg1: address) -> bytes <= 3:
     assert c2.get_array(c.address) == b'dog'
 
 
-def test_external_contract_call__state_change():
+def test_external_contract_call_state_change():
     contract_1 = """
 lucky: public(num)
 
@@ -98,6 +98,33 @@ def set_lucky(arg1: address, arg2: num):
     assert c.get_lucky() == 0
     c2.set_lucky(c.address, lucky_number)
     assert c.get_lucky() == lucky_number
+    print('Successfully executed an external contract call state change')
+
+
+def test_constant_external_contract_call_cannot_change_state():
+    contract_1 = """
+lucky: public(num)
+
+def set_lucky(_lucky: num):
+    self.lucky = _lucky
+    """
+
+    lucky_number = 7
+    c = get_contract(contract_1)
+
+    contract_2 = """
+class Foo():
+    def set_lucky(_lucky: num) -> num: pass
+
+@constant
+def set_lucky(arg1: address, arg2: num):
+    Foo(arg1).set_lucky(arg2)
+    """
+    c2 = get_contract(contract_2)
+
+    assert c.get_lucky() == 0
+    c2.set_lucky(c.address, lucky_number)
+    assert c.get_lucky() == 0
     print('Successfully executed an external contract call state change')
 
 

--- a/viper/opcodes.py
+++ b/viper/opcodes.py
@@ -68,6 +68,7 @@ opcodes = {
     'INVALID': [0xfe, 0, 0, 0],
     'SUICIDE': [0xff, 1, 0, 5000],
     'SELFDESTRUCT': [0xff, 1, 0, 25000],
+    'STATICCALL': [0xfa, 6, 1, 40],
 }
 
 pseudo_opcodes = {


### PR DESCRIPTION
Waiting to merge STATICALL or any byzantium features for the next ~30 days.
### - What I did
Add the `staticcall` opcode for `@constant` calls.
### - How I did it
Parser now checks if a function is `constant` made before making a call.
### - How to verify it
Look at the test I added.
### - Description for the changelog
Add staticcall opcode for constant function calls
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/31578233-fccc25e6-b0ea-11e7-888a-ad04472545f4.png)

