### PR TITLE
Update 'readthedocs' URL from 'eth-viper' to 'viper' (yay!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Join the chat at https://gitter.im/bethereum/viper](https://badges.gitter.im/ethereum/viper.svg)](https://gitter.im/ethereum/viper?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/ethereum/viper.svg?branch=master)](https://travis-ci.org/ethereum/viper)
-[![Documentation Status](https://readthedocs.org/projects/eth-viper/badge/?version=latest)](http://eth-viper.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/viper/badge/?version=latest)](http://viper.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://coveralls.io/repos/github/ethereum/viper/badge.svg?branch=master)](https://coveralls.io/github/ethereum/viper?branch=master)
 
 # Principles and Goals
@@ -31,7 +31,7 @@ Viper does NOT strive to be a 100% replacement for everything that can be done i
 **Note: Viper is still alpha software, use with care**
 
 # Installation 
-See the [Viper documentation](https://eth-viper.readthedocs.io/en/latest/installing-viper.html)
+See the [Viper documentation](https://viper.readthedocs.io/en/latest/installing-viper.html)
 for build instructions.
 
 # Compiling a contract
@@ -60,4 +60,4 @@ For testing strategy, please see [Testing](no-link)
 * See Issues tab, and feel free to submit your own issues 
 * Add PRs if you discover a solution to an existing issue
 * For further discussions and questions talk to us on [gitter](https://gitter.im/ethereum/viper)
-* For more information, see [Contributing](http://eth-viper.readthedocs.io/en/latest/contributing.html)
+* For more information, see [Contributing](http://viper.readthedocs.io/en/latest/contributing.html)

--- a/docs/old_readme.txt
+++ b/docs/old_readme.txt
@@ -1,7 +1,7 @@
 ## Contributing
 * See Issues above, and feel free to submit your own issues or PRs if you discover a solution
 * Further discussions and questions [chat on gitter](https://gitter.im/ethereum/viper)
-* For more information, see [Contributing](http://eth-viper.readthedocs.io/en/latest/contributing.html)
+* For more information, see [Contributing](http://viper.readthedocs.io/en/latest/contributing.html)
 
 [![Join the chat at https://gitter.im/bethereum/viper](https://badges.gitter.im/ethereum/viper.svg)](https://gitter.im/ethereum/viper?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/ethereum/viper.svg?branch=master)](https://travis-ci.org/ethereum/viper)


### PR DESCRIPTION
### - What I did

Updated 'eth-viper.readthedocs.io' to 'viper.readthedocs.io'

### - How to check it

```bash
bash:~/viper$ grep -r "eth-viper" .
```

### - Cute Animal Picture

![coffee](https://i.pinimg.com/736x/4a/1c/4a/4a1c4a9755e4d3bdfcb45a1c3a58712f--cup-of-coffee-coffee-time.jpg)
