### PR TITLE
Return tuple support

### DIFF
--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -54,3 +54,13 @@ def out_very_long_bytes() -> (num, bytes <= 1024, num, address):
     assert c.four() == [1234, b"bytes", b"test", 4321]
     assert c.out_chunk() == [b"hello", 5678, b"world"]
     assert c.out_very_long_bytes() == [5555, long_string.encode(), 6666, "0x0000000000000000000000000000000000001234"]
+
+
+def test_return_type_signatures():
+    code = """
+def out_literals() -> (num, address, bytes <= 4):
+    return 1, 0x0000000000000000000000000000000000000000, "random"
+    """
+
+    c = get_contract(code)
+    assert c.translator.function_data['out_literals']['decode_types'] == ['int128', 'address', 'bytes']

--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -1,0 +1,56 @@
+import pytest
+from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
+    get_contract_with_gas_estimation, get_contract
+
+
+def test_return_type():
+    long_string = 35 * "test"
+
+    code = """
+chunk: {
+    a: bytes <= 8,
+    b: bytes <= 8,
+    c: num
+}
+
+def __init__():
+    self.chunk.a = "hello"
+    self.chunk.b = "world"
+    self.chunk.c = 5678
+
+def out() -> (num, address):
+    return 3333, 0x0000000000000000000000000000000000000001
+
+def out_literals() -> (num, address, bytes <= 4):
+    return 1, 0x0000000000000000000000000000000000000000, "random"
+
+def out_bytes_first() -> (bytes <= 4, num):
+    return "test", 1234
+
+def out_bytes_a(x: num, y: bytes <= 4) -> (num, bytes <= 4):
+    return x, y
+
+def out_bytes_b(x: num, y: bytes <= 4) -> (bytes <= 4, num, bytes <= 4):
+    return y, x, y
+
+def four() -> (num, bytes <= 8, bytes <= 8, num):
+    return 1234, "bytes", "test", 4321
+
+
+def out_chunk() -> (bytes <= 8, num, bytes <= 8):
+    return self.chunk.a, self.chunk.c, self.chunk.b
+
+def out_very_long_bytes() -> (num, bytes <= 1024, num, address):
+    return 5555, "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest", 6666, 0x0000000000000000000000000000000000001234  # noqa
+    """
+
+    c = get_contract(code)
+
+    assert c.out() == [3333, "0x0000000000000000000000000000000000000001"]
+    assert c.out_literals() == [1, "0x0000000000000000000000000000000000000000", b"random"]
+    assert c.out_bytes_first() == [b"test", 1234]
+    assert c.out_bytes_a(5555555, "test") == [5555555, b"test"]
+    assert c.out_bytes_b(5555555, "test") == [b"test", 5555555, b"test"]
+    assert c.four() == [1234, b"bytes", b"test", 4321]
+    assert c.out_chunk() == [b"hello", 5678, b"world"]
+    assert c.out_very_long_bytes() == [5555, long_string.encode(), 6666, "0x0000000000000000000000000000000000001234"]

--- a/tests/parser/syntax/test_return_tuple.py
+++ b/tests/parser/syntax/test_return_tuple.py
@@ -1,0 +1,20 @@
+import pytest
+from pytest import raises
+
+from viper import compiler
+from viper.exceptions import StructureException
+
+
+fail_list = [
+    """
+def unmatched_tupl_length() -> (bytes <= 8, num, bytes <= 8):
+    return "test", 123
+    """
+]
+
+
+@pytest.mark.parametrize('bad_code', fail_list)
+def test_tuple_return_fail(bad_code):
+
+    with raises(StructureException):
+            compiler.compile(bad_code)

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -828,6 +828,17 @@ def parse_expr(expr, context):
             o[key.id] = parse_expr(value, context)
             members[key.id] = o[key.id].typ
         return LLLnode.from_list(["multi"] + [o[key] for key in sorted(list(o.keys()))], typ=StructType(members), pos=getpos(expr))
+
+    # Tuple literals
+    elif isinstance(expr, ast.Tuple):
+        if not len(expr.elts):
+            raise StructureException("Tuple must have elements", expr)
+        o = []
+        out_type = None
+        for elt in expr.elts:
+            o.append(parse_expr(elt, context))
+        return LLLnode.from_list(["multi"] + o, typ=TupleType(o), pos=getpos(expr))
+
     raise Exception("Unsupported operator: %r" % ast.dump(expr))
 
 

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -11,6 +11,7 @@ from viper.functions import (
 )
 from .parser_utils import LLLnode
 from .parser_utils import (
+    add_variable_offset,
     getpos,
     make_byte_array_copier,
     base_type_conversion,
@@ -20,6 +21,7 @@ from viper.types import (
     BaseType,
     ByteArrayType,
     ListType,
+    TupleType
 )
 from viper.types import (
     get_size_of_type,
@@ -265,7 +267,7 @@ class Stmt(object):
                 return LLLnode.from_list(o, typ=None, pos=getpos(self.stmt))
             else:
                 raise Exception("Invalid location: %s" % sub.location)
-        # Returning a list
+
         elif isinstance(sub.typ, ListType):
             if sub.location == "memory" and sub.value != "multi":
                 return LLLnode.from_list(['return', sub, get_size_of_type(self.context.return_type) * 32],
@@ -275,5 +277,51 @@ class Stmt(object):
                 setter = make_setter(new_sub, sub, 'memory')
                 return LLLnode.from_list(['seq', setter, ['return', new_sub, get_size_of_type(self.context.return_type) * 32]],
                                             typ=None, pos=getpos(self.stmt))
+
+        # Returning a tuple.
+        elif isinstance(sub.typ, TupleType):
+
+            subs = []
+            dynamic_offset_counter = LLLnode(self.context.get_next_mem(), typ=None, annotation="dynamic_offset_counter")  # dynamic offset position counter.
+            new_sub = LLLnode.from_list(self.context.get_next_mem() + 32, typ=self.context.return_type, location='memory', annotation='new_sub')
+            keyz = list(range(len(sub.typ.members)))
+            dynamic_offset_start = 32 * len(sub.args)  # The static list of args end.
+            left_token = LLLnode.from_list('_loc', typ=new_sub.typ, location="memory")
+
+            def get_dynamic_offset_value():
+                # Get value of dynamic offset counter.
+                return ['mload', dynamic_offset_counter]
+
+            def increment_dynamic_offset(dynamic_spot):
+                # Increment dyanmic offset counter in memory.
+                return ['mstore', dynamic_offset_counter,
+                                 ['add',
+                                        ['add', ['ceil32', ['mload', dynamic_spot]], 32],
+                                        ['mload', dynamic_offset_counter]]]
+
+            for i, typ in enumerate(keyz):
+                arg = sub.args[i]
+                variable_offset = LLLnode.from_list(['add', 32 * i, left_token], typ=arg.typ, annotation='variable_offset')
+                if isinstance(arg.typ, ByteArrayType):
+                    # Store offset pointer value.
+                    subs.append(['mstore', variable_offset, get_dynamic_offset_value()])
+
+                    # Store dynamic data, from offset pointer onwards.
+                    dynamic_spot = LLLnode.from_list(['add', left_token, get_dynamic_offset_value()], location="memory", typ=arg.typ, annotation='dyanmic_spot')
+                    subs.append(make_setter(dynamic_spot, arg, location="memory"))
+                    subs.append(increment_dynamic_offset(dynamic_spot))
+
+                elif isinstance(arg.typ, BaseType):
+                    subs.append(make_setter(variable_offset, arg, "memory"))
+                else:
+                    raise Exception("Can't return type %s as part of tuple", type(arg.typ))
+
+            setter = LLLnode.from_list(['seq',
+                ['mstore', dynamic_offset_counter, dynamic_offset_start],
+                ['with', '_loc', new_sub, ['seq'] + subs]], typ=None
+            )
+
+            return LLLnode.from_list(['seq', setter, ['return', new_sub, get_dynamic_offset_value()]],
+                                        typ=None, pos=getpos(self.stmt))
         else:
             raise TypeMismatchException("Can only return base type!", self.stmt)

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -11,7 +11,6 @@ from viper.functions import (
 )
 from .parser_utils import LLLnode
 from .parser_utils import (
-    add_variable_offset,
     getpos,
     make_byte_array_copier,
     base_type_conversion,

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -279,7 +279,8 @@ class Stmt(object):
 
         # Returning a tuple.
         elif isinstance(sub.typ, TupleType):
-
+            if len(self.context.return_type.members) != len(sub.typ.members):
+                raise StructureException("Tuple lengths don't match!")
             subs = []
             dynamic_offset_counter = LLLnode(self.context.get_next_mem(), typ=None, annotation="dynamic_offset_counter")  # dynamic offset position counter.
             new_sub = LLLnode.from_list(self.context.get_next_mem() + 32, typ=self.context.return_type, location='memory', annotation='new_sub')
@@ -306,7 +307,7 @@ class Stmt(object):
                     subs.append(['mstore', variable_offset, get_dynamic_offset_value()])
 
                     # Store dynamic data, from offset pointer onwards.
-                    dynamic_spot = LLLnode.from_list(['add', left_token, get_dynamic_offset_value()], location="memory", typ=arg.typ, annotation='dyanmic_spot')
+                    dynamic_spot = LLLnode.from_list(['add', left_token, get_dynamic_offset_value()], location="memory", typ=arg.typ, annotation='dynamic_spot')
                     subs.append(make_setter(dynamic_spot, arg, location="memory"))
                     subs.append(increment_dynamic_offset(dynamic_spot))
 

--- a/viper/types.py
+++ b/viper/types.py
@@ -317,12 +317,11 @@ def ceil32(x):
 
 
 # Gets the number of memory or storage keys needed to represent a given type
-def get_size_of_type(typ, in_return=False):
+def get_size_of_type(typ):
     if isinstance(typ, BaseType):
         return 1
     elif isinstance(typ, ByteArrayType):
-        return_offset = 1 if in_return else 0
-        return ceil32(typ.maxlen) // 32 + 2 + return_offset
+        return ceil32(typ.maxlen) // 32 + 2
     elif isinstance(typ, ListType):
         return get_size_of_type(typ.subtype) * typ.count
     elif isinstance(typ, MappingType):
@@ -330,7 +329,7 @@ def get_size_of_type(typ, in_return=False):
     elif isinstance(typ, StructType):
         return sum([get_size_of_type(v) for v in typ.members.values()])
     elif isinstance(typ, TupleType):
-        return sum([get_size_of_type(v, in_return) for v in typ.members])
+        return sum([get_size_of_type(v) for v in typ.members])
     else:
         raise Exception("Unexpected type: %r" % repr(typ))
 

--- a/viper/types.py
+++ b/viper/types.py
@@ -128,7 +128,7 @@ class TupleType(NodeType):
         return other.__class__ == StructType and other.members == self.members
 
     def __repr__(self):
-        return '[' + ', '.join([repr(m) for m in self.members]) + ']'
+        return '(' + ', '.join([repr(m) for m in self.members]) + ')'
 
 
 # Data structure for a "multi" object with a mixed type
@@ -155,9 +155,12 @@ def canonicalize_type(t, is_event=False):
         if not isinstance(t.subtype, (ListType, BaseType)):
             raise Exception("List of byte arrays not allowed")
         return canonicalize_type(t.subtype) + "[%d]" % t.count
+    if isinstance(t, TupleType):
+        return "({})".format(
+            ",".join(canonicalize_type(x) for x in t.subtypes)
+        )
     if not isinstance(t, BaseType):
         raise Exception("Cannot canonicalize non-base type: %r" % t)
-
     num256_override = True if t.override_signature == 'num256' else False
 
     t = t.typ
@@ -301,6 +304,9 @@ def parse_type(item, location):
         if not isinstance(item.comparators[0].n, int) or item.comparators[0].n <= 0:
             raise InvalidTypeException("Bad byte array length: %r" % item.comparators[0].n, item.comparators[0])
         return ByteArrayType(item.comparators[0].n)
+    elif isinstance(item, ast.Tuple):
+        members = [parse_type(x, location) for x in item.elts]
+        return TupleType(members)
     else:
         raise InvalidTypeException("Invalid type: %r" % ast.dump(item), item)
 
@@ -311,11 +317,12 @@ def ceil32(x):
 
 
 # Gets the number of memory or storage keys needed to represent a given type
-def get_size_of_type(typ):
+def get_size_of_type(typ, in_return=False):
     if isinstance(typ, BaseType):
         return 1
     elif isinstance(typ, ByteArrayType):
-        return ceil32(typ.maxlen) // 32 + 2
+        return_offset = 1 if in_return else 0
+        return ceil32(typ.maxlen) // 32 + 2 + return_offset
     elif isinstance(typ, ListType):
         return get_size_of_type(typ.subtype) * typ.count
     elif isinstance(typ, MappingType):
@@ -323,7 +330,7 @@ def get_size_of_type(typ):
     elif isinstance(typ, StructType):
         return sum([get_size_of_type(v) for v in typ.members.values()])
     elif isinstance(typ, TupleType):
-        return sum([get_size_of_type(v) for v in typ.members])
+        return sum([get_size_of_type(v, in_return) for v in typ.members])
     else:
         raise Exception("Unexpected type: %r" % repr(typ))
 


### PR DESCRIPTION
### - What I did

Contracts can return tuple types now.
*Note* this doesn't cover tuple assignment yet.

### - How I did it

- Patched function signature.
- Altered parse_return in stmt.py, lots of work to handle dynamic type in the tuple (ByteArray only for now).
- More details have be placed in the commits ;)

### - How to verify it

Check the tests.

### - Description for the changelog

Added support for return a tuple from a contract.

### - Cute Animal Picture

![](https://static.boredpanda.com/blog/wp-content/uploads/2014/03/cute-fluffy-animals-coverimage.jpg)
