### PR TITLE
BUG: Log exceptions have error and don't post the right message

### DIFF
--- a/viper/signatures/event_signature.py
+++ b/viper/signatures/event_signature.py
@@ -47,9 +47,9 @@ class EventSignature():
                 if not typ:
                     raise InvalidTypeException("Argument must have type", arg)
                 if not is_varname_valid(arg):
-                    raise VariableDeclarationException("Argument name invalid or reserved: " + arg.arg, arg)
+                    raise VariableDeclarationException("Argument name invalid or reserved: " + arg, arg)
                 if arg in (x.name for x in args):
-                    raise VariableDeclarationException("Duplicate function argument name: " + arg.arg, arg)
+                    raise VariableDeclarationException("Duplicate function argument name: " + arg, arg)
                 parsed_type = parse_type(typ, None)
                 args.append(VariableRecord(arg, pos, parsed_type, False))
                 if isinstance(parsed_type, ByteArrayType):


### PR DESCRIPTION
### - What I did

I was fooling around with logs and noticed the exceptions for reserved and duplicate wouldn't post because of `arg.arg` where `arg` is a string (and therefore doesn't have an inner member arg)

### - How to verify it

Run a test raising these two exceptions and verify that they now show you what specific log argument is reserved or duplicated

### - Description for the changelog

Bug with Log Exceptions