### PR TITLE
Added method to get list of logs with optional filtering

### DIFF
--- a/tests/examples/tokens/test_vipercoin.py
+++ b/tests/examples/tokens/test_vipercoin.py
@@ -4,7 +4,7 @@ from ethereum import utils
 from ethereum.abi import ValueOutOfBounds
 from ethereum.tools import tester
 
-from tests.setup_transaction_tests import assert_tx_failed, get_log
+from tests.setup_transaction_tests import assert_tx_failed, get_last_log
 
 
 TOKEN_NAME = "Vipercoin"
@@ -113,7 +113,7 @@ def test_transferFrom(token_tester, assert_tx_failed):
     assert contract.allowance(a0, a1) == 0
 
 
-def test_transfer_event(token_tester, get_log):
+def test_transfer_event(token_tester, get_last_log):
     a0 = token_tester.accounts[0]
     a1 = token_tester.accounts[1]
     k1 = token_tester.k1
@@ -123,7 +123,7 @@ def test_transfer_event(token_tester, get_log):
 
     assert contract.transfer(a1, 1) is True
 
-    assert get_log(tester, contract, 'Transfer') == {
+    assert get_last_log(tester, contract) == {
         '_from': '0x' + a0.hex(),
         '_to': '0x' + a1.hex(),
         '_value': 1,
@@ -134,7 +134,7 @@ def test_transfer_event(token_tester, get_log):
     assert contract.approve(a1, 10) is True  # approve 10 token transfers to a1.
     assert contract.transferFrom(a0, a2, 4, sender=k1)  # transfer to a2, as a1, from a0's funds.
 
-    assert get_log(tester, contract, 'Transfer') == {
+    assert get_last_log(tester, contract) == {
         '_from': '0x' + a0.hex(),
         '_to': '0x' + a2.hex(),
         '_value': 4,
@@ -142,7 +142,7 @@ def test_transfer_event(token_tester, get_log):
     }
 
 
-def test_approval_event(token_tester, get_log):
+def test_approval_event(token_tester, get_last_log):
     a0 = token_tester.accounts[0]
     a1 = token_tester.accounts[1]
 
@@ -150,7 +150,7 @@ def test_approval_event(token_tester, get_log):
 
     assert contract.approve(a1, 10) is True  # approve 10 token transfers to a1.
 
-    assert get_log(tester, contract, 'Approval') == {
+    assert get_last_log(tester, contract) == {
         '_owner': '0x' + a0.hex(),
         '_spender': '0x' + a1.hex(),
         '_value': 10,

--- a/tests/setup_transaction_tests.py
+++ b/tests/setup_transaction_tests.py
@@ -103,26 +103,25 @@ negative_G1 = [
 
 curve_order = 21888242871839275222246405745257275088548364400416034343698204186575808495617
 
+def get_logs(receipt, contract, event_name=None):
+    contract_log_ids = contract.translator.event_data.keys() # All the log ids contract has
+    # All logs originating from contract, and matching event_name (if specified)
+    logs = [log for log in receipt.logs \
+        if log.topics[0] in contract_log_ids and \
+            log.address == contract.address and \
+            (not event_name or \
+                    contract.translator.event_data[log.topics[0]]['name'] == event_name)]
+    assert len(logs) > 0, "No logs in last receipt"
+
+    # Return all events decoded in the receipt
+    return [contract.translator.decode_event(log.topics, log.data) for log in logs]
+
 @pytest.fixture
 def get_log():
     def get_log(tester, contract, event_name):
-        event_ids_w_name = [k for k, v in \
-                contract.translator.event_data.items() if v["name"] == event_name]
-        assert len(event_ids_w_name) == 1, \
-                "Contract doesn't have event {}!".format(event_name)
-        event_id = event_ids_w_name[0]
-
-        # Get the last logged event
-        logs = tester.s.head_state.receipts[-1].logs[-1]
-
-        # Ensure it has the event we are looking to decode
-        assert logs.address == contract.address, \
-                "This contract didn't originate the last event!"
-        assert logs.topics[0] == event_id, \
-                "The last event wasn't {}!".format(event_name)
-
-        # Return the decoded event data
-        return contract.translator.decode_event(logs.topics, logs.data)
+        receipt = tester.s.head_state.receipts[-1] # Only the receipts for the last block
+        # Get last log event with correct name and return the decoded event
+        return get_logs(receipt, contract, event_name=event_name)[-1]
     return get_log
 
 @pytest.fixture

--- a/tests/setup_transaction_tests.py
+++ b/tests/setup_transaction_tests.py
@@ -117,12 +117,12 @@ def get_logs(receipt, contract, event_name=None):
     return [contract.translator.decode_event(log.topics, log.data) for log in logs]
 
 @pytest.fixture
-def get_log():
-    def get_log(tester, contract, event_name=None):
+def get_last_log():
+    def get_last_log(tester, contract, event_name=None):
         receipt = tester.s.head_state.receipts[-1] # Only the receipts for the last block
         # Get last log event with correct name and return the decoded event
         return get_logs(receipt, contract, event_name=event_name)[-1]
-    return get_log
+    return get_last_log
 
 @pytest.fixture
 def assert_tx_failed():

--- a/tests/setup_transaction_tests.py
+++ b/tests/setup_transaction_tests.py
@@ -118,7 +118,7 @@ def get_logs(receipt, contract, event_name=None):
 
 @pytest.fixture
 def get_log():
-    def get_log(tester, contract, event_name):
+    def get_log(tester, contract, event_name=None):
         receipt = tester.s.head_state.receipts[-1] # Only the receipts for the last block
         # Get last log event with correct name and return the decoded event
         return get_logs(receipt, contract, event_name=event_name)[-1]


### PR DESCRIPTION
### - What I did

Added `get_logs()` function to retrieve the list of logs produced by a contract in a given receipt, optional filtering argument to only collect logs of a specific type
Changed `get_log` fixture to use this new function (returning the last log in the filtered list)

### - How to verify it

Tests all work, let me know if there are any concerns

### - Description for the changelog

Added get_logs(), redefined get_log fixture to use get_logs()

### - Cute Animal Picture

![turtle](http://www.critterbabies.com/wp-content/gallery/turtles/happy-baby-turtle-is-happy-big.jpg)
