### PR TITLE
Fixes generating of ABI, if only __init__ function exists.

### DIFF
--- a/tests/parser/functions/test_only_init_abi.py
+++ b/tests/parser/functions/test_only_init_abi.py
@@ -1,0 +1,19 @@
+from viper.compiler import mk_full_signature
+
+
+def test_only_init_function():
+    code = """
+x: num
+
+def __init__():
+    self.x = 1
+    """
+
+    assert mk_full_signature(code) == [{
+        'name': '__init__',
+        'outputs': [],
+        'inputs': [],
+        'constant': False,
+        'payable': False,
+        'type': 'constructor'
+    }]

--- a/tests/parser/functions/test_only_init_abi.py
+++ b/tests/parser/functions/test_only_init_abi.py
@@ -8,8 +8,14 @@ x: num
 def __init__():
     self.x = 1
     """
+    code_init_empty = """
+x: num
 
-    assert mk_full_signature(code) == [{
+def __init__():
+    pass
+    """
+
+    empty_sig = [{
         'name': '__init__',
         'outputs': [],
         'inputs': [],
@@ -17,3 +23,6 @@ def __init__():
         'payable': False,
         'type': 'constructor'
     }]
+
+    assert mk_full_signature(code) == empty_sig
+    assert mk_full_signature(code_init_empty) == empty_sig

--- a/viper/compiler.py
+++ b/viper/compiler.py
@@ -15,9 +15,11 @@ def compile(code, *args, **kwargs):
 def gas_estimate(origcode, *args, **kwargs):
     o = {}
     code = optimizer.optimize(parser.parse_to_lll(origcode))
+
     # Extract the stuff inside the LLL bracket
     if code.value == 'seq':
-        code = code.args[-1].args[1].args[0]
+        if code.args[-1].value == 'return':
+            code = code.args[-1].args[1].args[0]
     else:
         code = code.args[1].args[0]
     assert code.value == 'seq'

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -62,9 +62,7 @@ from viper.utils import (
 )
 
 
-try:
-    x = ast.AnnAssign
-except:
+if not hasattr(ast, 'AnnAssign'):
     raise Exception("Requires python 3.6 or higher for annotation support")
 
 


### PR DESCRIPTION
### - What I did

Fixes single __init__ function contract error in mksignature. See #423

### - How I did it

- Looked at how gas_estimate interprets the LLL code layout, doesn't take into account a scenario where there are no additional function after the init code section.

### - How to verify it

Check test, create a a single __init__() contract.

### - Description for the changelog

### - Cute Animal Picture
![](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-32.jpg)
