### PR TITLE
Add extra line numbers to exceptions.

### DIFF
--- a/tests/parser/exceptions/test_parser_exception_pos.py
+++ b/tests/parser/exceptions/test_parser_exception_pos.py
@@ -1,0 +1,14 @@
+from pytest import raises
+
+from viper.exceptions import ParserException
+
+
+def test_type_exception_pos():
+    pos = (1, 2)
+
+    with raises(ParserException) as e:
+        raise ParserException('Fail!', pos)
+
+    assert e.value.lineno == 1
+    assert e.value.col_offset == 2
+    assert str(e.value) == 'line 1:2 Fail!'

--- a/viper/exceptions.py
+++ b/viper/exceptions.py
@@ -2,11 +2,12 @@
 class ParserException(Exception):
     def __init__(self, message='Error Message not found.', item=None):
         self.message = message
-
         self.lineno = None
         self.col_offset = None
 
-        if item and hasattr(item, 'lineno'):
+        if isinstance(item, tuple):  # is a position.
+            self.lineno, self.col_offset = item
+        elif item and hasattr(item, 'lineno'):
             self.set_err_pos(item.lineno, item.col_offset)
             if hasattr(item, 'source_code'):
                 self.source_code = item.source_code.splitlines()
@@ -21,7 +22,8 @@ class ParserException(Exception):
     def __str__(self):
         output = self.message
 
-        if self.lineno:
+        if self.lineno and hasattr(self, 'source_code'):
+
             output = 'line %d: %s\n%s' % (
                 self.lineno,
                 output,
@@ -31,6 +33,13 @@ class ParserException(Exception):
             if self.col_offset:
                 col = '-' * self.col_offset + '^'
                 output += '\n' + col
+
+        elif self.lineno and self.col_offset:
+            output = 'line %d:%d %s' % (
+                self.lineno,
+                self.col_offset,
+                output
+            )
 
         return output
 

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -62,9 +62,7 @@ from viper.utils import (
 )
 
 
-try:
-    x = ast.AnnAssign
-except:
+if not hasattr(ast, 'AnnAssign'):
     raise Exception("Requires python 3.6 or higher for annotation support")
 
 

--- a/viper/parser/parser_utils.py
+++ b/viper/parser/parser_utils.py
@@ -395,10 +395,10 @@ def add_variable_offset(parent, key):
 
 
 # Convert from one base type to another
-def base_type_conversion(orig, frm, to):
+def base_type_conversion(orig, frm, to, pos=None):
     orig = unwrap_location(orig)
     if not isinstance(frm, (BaseType, NullType)) or not isinstance(to, BaseType):
-        raise TypeMismatchException("Base type conversion from or to non-base type: %r %r" % (frm, to))
+        raise TypeMismatchException("Base type conversion from or to non-base type: %r %r" % (frm, to), pos)
     elif is_base_type(frm, to.typ) and are_units_compatible(frm, to):
         return LLLnode(orig.value, orig.args, typ=to)
     elif is_base_type(frm, 'num') and is_base_type(to, 'decimal') and are_units_compatible(frm, to):
@@ -407,10 +407,10 @@ def base_type_conversion(orig, frm, to):
         return LLLnode.from_list(['uclample', orig, ['mload', MemoryPositions.MAXNUM]], typ=BaseType("num"))
     elif isinstance(frm, NullType):
         if to.typ not in ('num', 'bool', 'num256', 'address', 'bytes32', 'decimal'):
-            raise TypeMismatchException("Cannot convert null-type object to type %r" % to)
+            raise TypeMismatchException("Cannot convert null-type object to type %r" % to, pos)
         return LLLnode.from_list(0, typ=to)
     else:
-        raise TypeMismatchException("Typecasting from base type %r to %r unavailable" % (frm, to))
+        raise TypeMismatchException("Typecasting from base type %r to %r unavailable" % (frm, to), pos)
 
 
 # Unwrap location

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -84,14 +84,14 @@ class Stmt(object):
         if isinstance(self.stmt.targets[0], ast.Name) and self.stmt.targets[0].id not in self.context.vars:
             pos = self.context.new_variable(self.stmt.targets[0].id, set_default_units(sub.typ))
             variable_loc = LLLnode.from_list(pos, typ=sub.typ, location='memory', pos=getpos(self.stmt), annotation=self.stmt.targets[0].id)
-            o = make_setter(variable_loc, sub, 'memory')
+            o = make_setter(variable_loc, sub, 'memory', pos=getpos(self.stmt))
         else:
             target = parse_variable_location(self.stmt.targets[0], self.context)
             if target.location == 'storage' and self.context.is_constant:
                 raise ConstancyViolationException("Cannot modify storage inside a constant function!", self.stmt.targets[0])
             if not target.mutable:
                 raise ConstancyViolationException("Cannot modify function argument", self.stmt.targets[0])
-            o = make_setter(target, sub, target.location)
+            o = make_setter(target, sub, target.location, pos=getpos(self.stmt))
         o.pos = getpos(self.stmt)
         return o
 
@@ -273,7 +273,7 @@ class Stmt(object):
                                             typ=None, pos=getpos(self.stmt))
             else:
                 new_sub = LLLnode.from_list(self.context.new_placeholder(self.context.return_type), typ=self.context.return_type, location='memory')
-                setter = make_setter(new_sub, sub, 'memory')
+                setter = make_setter(new_sub, sub, 'memory', pos=getpos(self.stmt))
                 return LLLnode.from_list(['seq', setter, ['return', new_sub, get_size_of_type(self.context.return_type) * 32]],
                                             typ=None, pos=getpos(self.stmt))
 
@@ -308,11 +308,11 @@ class Stmt(object):
 
                     # Store dynamic data, from offset pointer onwards.
                     dynamic_spot = LLLnode.from_list(['add', left_token, get_dynamic_offset_value()], location="memory", typ=arg.typ, annotation='dynamic_spot')
-                    subs.append(make_setter(dynamic_spot, arg, location="memory"))
+                    subs.append(make_setter(dynamic_spot, arg, location="memory", pos=getpos(self.stmt)))
                     subs.append(increment_dynamic_offset(dynamic_spot))
 
                 elif isinstance(arg.typ, BaseType):
-                    subs.append(make_setter(variable_offset, arg, "memory"))
+                    subs.append(make_setter(variable_offset, arg, "memory", pos=getpos(self.stmt)))
                 else:
                     raise Exception("Can't return type %s as part of tuple", type(arg.typ))
 


### PR DESCRIPTION
### - What I did

- Added optional pos parameters, which can be used by various TypeMismatchException 's to show the programmer where the error occurred.
- #415 

### - How I did it
Looked at TypeMismatchException ;)

### - How to verify it
Example program:
```python
x: num

def __init__():
    self.x = "test"
```
Will generate a more useful exception now:
```
viper.exceptions.TypeMismatchException: line 5:4 Base type conversion from or to non-base type: bytes <= 4 num
```
### - Description for the changelog

### - Cute Animal Picture
![](https://i.pinimg.com/originals/8d/4f/e2/8d4fe2038ee81d2f75670928aefc48aa.jpg)