### PR TITLE
If in a list support

### DIFF
--- a/tests/parser/features/iteration/test_range_in.py
+++ b/tests/parser/features/iteration/test_range_in.py
@@ -1,6 +1,7 @@
 import pytest
 from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
     get_contract_with_gas_estimation, get_contract
+from viper.exceptions import TypeMismatchException
 
 
 def test_basic_in_list():
@@ -59,3 +60,15 @@ def in_test(x: num) -> bool:
     assert c.in_test(-9) is False
     assert c.in_test(5) is True
     assert c.in_test(7) is True
+
+
+def test_mixed_in_list():
+    code = """
+def testin() -> bool:
+    s = [1, 2, 3, 4]
+    if "test" in s:
+        return True
+    return False
+    """
+    with pytest.raises(TypeMismatchException):
+        c = get_contract(code)

--- a/tests/parser/features/iteration/test_range_in.py
+++ b/tests/parser/features/iteration/test_range_in.py
@@ -24,20 +24,6 @@ def testin(x: num) -> bool:
     assert c.testin(-1) is False
 
 
-# def test_cmp_in_list():
-#     code = """
-# def in_test(x: num) -> bool:
-#     if x in [9, 7, 6, 5]:
-#         return True
-#     return False
-#     """
-
-#     c = get_contract(code)
-
-#     assert c.in_test(1) == True
-#     assert c.in_test(5) == False
-
-
 def test_in_storage_list():
     code = """
 allowed: num[10]
@@ -50,7 +36,26 @@ def in_test(x: num) -> bool:
     """
 
     c = get_contract(code)
-    assert c.in_test(1) == True
-    assert c.in_test(9) == True
-    assert c.in_test(11) == False
-    assert c.in_test(-1) == False
+
+    assert c.in_test(1) is True
+    assert c.in_test(9) is True
+    assert c.in_test(11) is False
+    assert c.in_test(-1) is False
+    assert c.in_test(32000) is False
+
+
+def test_cmp_in_list():
+    code = """
+def in_test(x: num) -> bool:
+    if x in [9, 7, 6, 5]:
+        return True
+    return False
+    """
+
+    c = get_contract(code)
+
+    assert c.in_test(1) is False
+    assert c.in_test(-7) is False
+    assert c.in_test(-9) is False
+    assert c.in_test(5) is True
+    assert c.in_test(7) is True

--- a/tests/parser/features/iteration/test_range_in.py
+++ b/tests/parser/features/iteration/test_range_in.py
@@ -1,0 +1,37 @@
+import pytest
+from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
+    get_contract_with_gas_estimation, get_contract
+
+
+def test_basic_in_list():
+    code = """
+def testin(x: num) -> bool:
+    s = [1, 2, 3, 4]
+    if x in s:
+        return True
+    return False
+    """
+
+    c = get_contract(code)
+
+    assert c.testin(1) is True
+    assert c.testin(2) is True
+    assert c.testin(3) is True
+    assert c.testin(4) is True
+    assert c.testin(5) is False
+    assert c.testin(0) is False
+    assert c.testin(-1) is False
+
+
+# def test_cmp_in_list():
+#     code = """
+# def in_test(x: num) -> bool:
+#     if x in [9, 7, 6, 5]:
+#         return True
+#     return False
+#     """
+
+#     c = get_contract(code)
+
+#     assert c.in_test(1) == True
+#     assert c.in_test(5) == False

--- a/tests/parser/features/iteration/test_range_in.py
+++ b/tests/parser/features/iteration/test_range_in.py
@@ -6,20 +6,21 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 def test_basic_in_list():
     code = """
 def testin(x: num) -> bool:
+    y = 1
     s = [1, 2, 3, 4]
-    if x in s:
+    if (x + 1) in s:
         return True
     return False
     """
 
     c = get_contract(code)
 
+    assert c.testin(0) is True
     assert c.testin(1) is True
     assert c.testin(2) is True
     assert c.testin(3) is True
-    assert c.testin(4) is True
+    assert c.testin(4) is False
     assert c.testin(5) is False
-    assert c.testin(0) is False
     assert c.testin(-1) is False
 
 
@@ -35,3 +36,21 @@ def testin(x: num) -> bool:
 
 #     assert c.in_test(1) == True
 #     assert c.in_test(5) == False
+
+
+def test_in_storage_list():
+    code = """
+allowed: num[10]
+
+def in_test(x: num) -> bool:
+    self.allowed = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    if x in self.allowed:
+        return True
+    return False
+    """
+
+    c = get_contract(code)
+    assert c.in_test(1) == True
+    assert c.in_test(9) == True
+    assert c.in_test(11) == False
+    assert c.in_test(-1) == False

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -304,7 +304,11 @@ class Expr(object):
         right = Expr(self.expr.comparators[0], self.context).lll_node
 
         result_placeholder = self.context.new_placeholder(BaseType('bool'))
-        load_i_from_list = ['mload', ['add', right, ['mul', 32, ['mload', MemoryPositions.FREE_LOOP_INDEX]]]]
+
+        if right.location == "storage":
+            load_i_from_list = ['sload', ['add', ['sha3_32', right], ['mload', MemoryPositions.FREE_LOOP_INDEX]]]
+        else:
+            load_i_from_list = ['mload', ['add', right, ['mul', 32, ['mload', MemoryPositions.FREE_LOOP_INDEX]]]]
 
         break_loop_condition = [
             'if',
@@ -321,10 +325,9 @@ class Expr(object):
                 ['with', '_result', result_placeholder,
                     ['repeat', MemoryPositions.FREE_LOOP_INDEX, 0, right.typ.count, break_loop_condition]],
                 ['mload', result_placeholder]]],
-            typ='bool'
+            typ='bool',
+            annotation="in comporator"
         )
-
-        # LLLnode.from_list([op, left, right], typ='bool', pos=getpos(self.expr))
 
         return o
 

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -360,8 +360,9 @@ class Expr(object):
         left = Expr.parse_value_expr(self.expr.left, self.context)
         right = Expr.parse_value_expr(self.expr.comparators[0], self.context)
         if isinstance(self.expr.ops[0], ast.In) and \
-           is_numeric_type(left.typ) and \
            isinstance(right.typ, ListType):
+            if not are_units_compatible(left.typ, right.typ.subtype) and not are_units_compatible(right.typ.subtype, left.typ):
+                raise TypeMismatchException("Can't use IN comparison with different types!", self.expr)
             return self.build_in_comparator()
         else:
             if not are_units_compatible(left.typ, right.typ) and not are_units_compatible(right.typ, left.typ):

--- a/viper/types.py
+++ b/viper/types.py
@@ -352,7 +352,9 @@ def set_default_units(typ):
 
 # Checks that the units of frm can be seamlessly converted into the units of to
 def are_units_compatible(frm, to):
-    return frm.unit is None or (frm.unit == to.unit and frm.positional == to.positional)
+    frm_unit = getattr(frm, 'unit', 0)
+    to_unit = getattr(to, 'unit', 0)
+    return frm_unit is None or (frm_unit == to_unit and frm.positional == to.positional)
 
 
 # Is a type representing a number?


### PR DESCRIPTION
### - What I did
Implements #428, we can now use `x in [1, 2, 3, 4]` syntax :smiley_cat: 

### - How I did it

- Added handling for the specific case in expr.py/Expr.compare function.

### - How to verify it
Check tests, and write some code:

```python
allowed: num[10]


def set():
    self.allowed = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]


def in_test(x: num) -> bool:
    if x in self.allowed:
            return True
    return False
```

### - Description for the changelog

### - Cute Animal Picture

![](https://static.boredpanda.com/blog/wp-content/uploads/2016/08/cute-kittens-29-57b30ad229af3__605.jpg)