### PR TITLE
Add msg.gas functionality

### DIFF
--- a/tests/parser/features/test_gas.py
+++ b/tests/parser/features/test_gas.py
@@ -1,0 +1,17 @@
+import pytest
+from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
+    get_contract_with_gas_estimation, get_contract
+
+
+def test_gas_call():
+    gas_call = """
+
+def foo() -> num:
+    return msg.gas
+    """
+
+    c = get_contract_with_gas_estimation(gas_call)
+
+    assert c.foo(startgas = 50000) < 50000
+    assert c.foo(startgas = 50000) > 25000
+    print('Passed gas test')

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -173,6 +173,8 @@ class Expr(object):
                 if not self.context.is_payable:
                     raise NonPayableViolationException("Cannot use msg.value in a non-payable function", self.expr)
                 return LLLnode.from_list(['callvalue'], typ=BaseType('num', {'wei': 1}), pos=getpos(self.expr))
+            elif key == "msg.gas":
+                return LLLnode.from_list(['gas'], typ='num', pos=getpos(self.expr))
             elif key == "block.difficulty":
                 return LLLnode.from_list(['difficulty'], typ='num', pos=getpos(self.expr))
             elif key == "block.timestamp":


### PR DESCRIPTION
### - What I did

Add msg.gas call functionality.

### - How I did it

Add lines on msg.gas into expr.py and create test_gas.py for tests.

### - How to verify it

You can now use `msg.gas` in a contract to check for remaining gas.

### - Description for the changelog

Add msg.gas call functionality.

### - Cute Animal Picture

![cute-turtle-3](https://user-images.githubusercontent.com/5008104/32086887-3f1cf686-baa6-11e7-873d-f242774effed.jpg)


> put a cute animal picture here.
