### PR TITLE
Added 'is_varname_valid()' check for globals

### DIFF
--- a/tests/parser/exceptions/test_variable_declaration_exception.py
+++ b/tests/parser/exceptions/test_variable_declaration_exception.py
@@ -77,6 +77,9 @@ def goo():
     """
 def foo():
     BALANCE = 45
+    """,
+    """
+num: num
     """
 ]
 

--- a/tests/parser/globals/test_setters.py
+++ b/tests/parser/globals/test_setters.py
@@ -118,7 +118,7 @@ def test_type_converter_setter_test():
     type_converter_setter_test = """
 mom: {a: {c: num}[3], b: num}
 non: {a: {c: decimal}[3], b:num}
-pop: decimal[2][2]
+pap: decimal[2][2]
 
 def foo() -> num:
     self.mom = {a: [{c: 1}, {c: 2}, {c: 3}], b: 4}
@@ -126,8 +126,8 @@ def foo() -> num:
     return floor(self.non.a[0].c + self.non.a[1].c * 10 + self.non.a[2].c * 100 + self.non.b * 1000)
 
 def goo() -> num:
-    self.pop = [[1, 2], [3, 4.0]]
-    return floor(self.pop[0][0] + self.pop[0][1] * 10 + self.pop[1][0] * 100 + self.pop[1][1] * 1000)
+    self.pap = [[1, 2], [3, 4.0]]
+    return floor(self.pap[0][0] + self.pap[0][1] * 10 + self.pap[1][0] * 100 + self.pap[1][1] * 1000)
     """
 
     c = get_contract(type_converter_setter_test)

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -161,6 +161,9 @@ def add_globals_and_events(_defs, _events, _getters, _globals, item):
         _events.append(item)
     elif not isinstance(item.target, ast.Name):
         raise StructureException("Can only assign type to variable in top-level statement", item)
+    # Check if variable name is reserved or invalid
+    elif not is_varname_valid(item.target.id):
+        raise VariableDeclarationException("Variable name invalid or reserved: ", item.target)
     # Check if global already exists, if so error
     elif item.target.id in _globals:
         raise VariableDeclarationException("Cannot declare a persistent variable twice!", item.target)


### PR DESCRIPTION
### - What I did
Globals could contain reserved words. I added a check for "is_varname_valid()".
### - How I did it
See "parser.py".
Additionally, "test_setters.py" had to be changed, since it contained the opcode "pop" as a variable.
### - How to verify it
See "test_variable_declaration_exception.py".
### - Description for the changelog
Globals can not have invalid names anymore.
### - Cute Animal Picture
![](https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Martes_flavigula%2C_yellow-throated_marten.jpg/800px-Martes_flavigula%2C_yellow-throated_marten.jpg)
