### PR TITLE
Fix logging gas estimation

### DIFF
--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -42,7 +42,8 @@ from viper.types import (
 from viper.utils import (
     MemoryPositions,
     LOADED_LIMIT_MAP,
-    reserved_words
+    reserved_words,
+    string_to_bytes
 )
 from viper.utils import (
     bytes_to_int,
@@ -600,12 +601,7 @@ def pack_logging_topics(event_id, args, topics_types, context):
             if input.typ.maxlen > typ.maxlen:
                 raise TypeMismatchException("Topic input bytes are to big: %r %r" % (input.typ, typ))
             if isinstance(arg, ast.Str):
-                bytez = b''
-                for c in arg.s:
-                    if ord(c) >= 256:
-                        raise InvalidLiteralException("Cannot insert special character %r into byte array" % c)
-                    bytez += bytes([ord(c)])
-                bytez_length = len(bytez)
+                bytez, bytez_length = string_to_bytes(arg.s)
                 if len(bytez) > 32:
                     raise InvalidLiteralException("Can only log a maximum of 32 bytes at a time.")
                 topics.append(bytes_to_int(bytez + b'\x00' * (32 - bytez_length)))

--- a/viper/utils.py
+++ b/viper/utils.py
@@ -1,7 +1,7 @@
 import binascii
 
 from collections import OrderedDict
-
+from . exceptions import InvalidLiteralException
 from .opcodes import opcodes
 
 try:
@@ -15,6 +15,17 @@ except ImportError:
 # Converts for bytes to an integer
 def fourbytes_to_int(inp):
     return (inp[0] << 24) + (inp[1] << 16) + (inp[2] << 8) + inp[3]
+
+
+# Converts string to bytes
+def string_to_bytes(str):
+    bytez = b''
+    for c in str:
+        if ord(c) >= 256:
+            raise InvalidLiteralException("Cannot insert special character %r into byte array" % c)
+        bytez += bytes([ord(c)])
+    bytez_length = len(bytez)
+    return bytez, bytez_length
 
 
 # Converts a provided hex string to an integer


### PR DESCRIPTION
### - What I did
Switch logging topic packaging to compile time to save gas.
### - How I did it
Move string literals translation (`strings to bytes`) to the compiler level instead of the evm level.
### - How to verify it
Look at the code I changed to make sure the end functionality is the same.
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/32139030-c831b314-bc0c-11e7-9368-3833249dca82.png)

