### PR TITLE
For in list support

### DIFF
--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -1,7 +1,6 @@
 import pytest
 from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
     get_contract_with_gas_estimation, get_contract
-from viper.exceptions import TypeMismatchException
 
 
 def test_basic_for_in_list():
@@ -52,3 +51,80 @@ def data() -> num:
     assert c.data() == -1
     assert c.set() is None
     assert c.data() == 7
+
+
+def test_basic_for_list_address():
+    code = """
+def data() -> address:
+    addresses = [
+        0x7d577a597B2742b498Cb5Cf0C26cDCD726d39E6e,
+        0x82A978B3f5962A5b0957d9ee9eEf472EE55B42F1,
+        0xDCEceAF3fc5C0a63d195d69b1A90011B7B19650D
+    ]
+    count = 0
+    for i in addresses:
+        count += 1
+        if count == 2:
+            return i
+    return 0x0000000000000000000000000000000000000000
+    """
+
+    c = get_contract(code)
+
+    assert c.data() == "0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1"
+
+
+def test_basic_for_list_storage_address():
+    code = """
+addresses: address[3]
+
+def set(i: num, val: address):
+    self.addresses[i] = val
+
+def ret(i: num) -> address:
+    return self.addresses[i]
+
+def iterate_return_second() -> address:
+    count = 0
+    for i in self.addresses:
+        count += 1
+        if count == 2:
+            return i
+    """
+
+    c = get_contract(code)
+
+    c.set(0, '0x82A978B3f5962A5b0957d9ee9eEf472EE55B42F1')
+    c.set(1, '0x7d577a597B2742b498Cb5Cf0C26cDCD726d39E6e')
+    c.set(2, '0xDCEceAF3fc5C0a63d195d69b1A90011B7B19650D')
+
+    assert c.ret(1) == c.iterate_return_second() == "0x7d577a597b2742b498cb5cf0c26cdcd726d39e6e"
+
+
+def test_basic_for_list_storage_decimal():
+    code = """
+readings: decimal[3]
+
+def set(i: num, val: decimal):
+    self.readings[i] = val
+
+def ret(i: num) -> decimal:
+    return self.readings[i]
+
+def i_return(break_count: num) -> decimal:
+    count = 0
+    for i in self.readings:
+        if count == break_count:
+            return i
+        count += 1
+    """
+
+    c = get_contract(code)
+
+    c.set(0, 0.0001)
+    c.set(1, 1.1)
+    c.set(2, 2.2)
+
+    assert c.ret(2) == c.i_return(2) == 2.2
+    assert c.ret(1) == c.i_return(1) == 1.1
+    assert c.ret(0) == c.i_return(0) == 0.0001

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -1,0 +1,18 @@
+import pytest
+from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
+    get_contract_with_gas_estimation, get_contract
+
+
+def test_basic_in_list():
+    code = """
+def data() -> num:
+    s = [1, 2, 3, 4, 5, 6]
+    for i in s:
+        if i >= 3:
+            return i
+    return -1
+    """
+
+    c = get_contract(code)
+
+    assert c.data() == 3

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -1,6 +1,7 @@
 import pytest
 from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
     get_contract_with_gas_estimation, get_contract
+from viper.exceptions import TypeMismatchException
 
 
 def test_basic_in_list():
@@ -16,3 +17,17 @@ def data() -> num:
     c = get_contract(code)
 
     assert c.data() == 3
+
+
+def test_basic_in_list():
+    code = """
+def data() -> num:
+    for i in [3, 5, 7, 9]:
+        if i > 5:
+            return i
+    return -1
+    """
+
+    c = get_contract(code)
+
+    assert c.data() == 7

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -4,7 +4,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 from viper.exceptions import TypeMismatchException
 
 
-def test_basic_in_list():
+def test_basic_for_in_list():
     code = """
 def data() -> num:
     s = [1, 2, 3, 4, 5, 6]
@@ -19,7 +19,7 @@ def data() -> num:
     assert c.data() == 3
 
 
-def test_basic_in_list():
+def test_basic_for_list_liter():
     code = """
 def data() -> num:
     for i in [3, 5, 7, 9]:
@@ -30,4 +30,25 @@ def data() -> num:
 
     c = get_contract(code)
 
+    assert c.data() == 7
+
+
+def test_basic_for_list_storage():
+    code = """
+x: num[4]
+
+def set():
+    self.x = [3, 5, 7, 9]
+
+def data() -> num:
+    for i in self.x:
+        if i > 5:
+            return i
+    return -1
+    """
+
+    c = get_contract(code)
+
+    assert c.data() == -1
+    assert c.set() is None
     assert c.data() == 7

--- a/tests/parser/syntax/test_nested_list.py
+++ b/tests/parser/syntax/test_nested_list.py
@@ -2,7 +2,7 @@ import pytest
 from pytest import raises
 
 from viper import compiler
-from viper.exceptions import TypeMismatchException
+from viper.exceptions import TypeMismatchException, StructureException
 
 
 fail_list = [
@@ -30,7 +30,7 @@ y: address[2][2]
 def foo(x: num[2][2]) -> num:
     self.y = x
     """,
-    """
+    ("""
 bar: num[3][3]
 
 def foo() -> num[3]:
@@ -38,15 +38,19 @@ def foo() -> num[3]:
     for x in self.bar:
         if x == [4, 5, 6]:
             return x
-    """
+    """, StructureException)
 ]
 
 
 @pytest.mark.parametrize('bad_code', fail_list)
 def test_nested_list_fail(bad_code):
 
-    with raises(TypeMismatchException):
-        compiler.compile(bad_code)
+    if isinstance(bad_code, tuple):
+        with raises(bad_code[1]):
+            compiler.compile(bad_code[0])
+    else:
+        with raises(TypeMismatchException):
+            compiler.compile(bad_code)
 
 
 valid_list = [

--- a/tests/parser/syntax/test_nested_list.py
+++ b/tests/parser/syntax/test_nested_list.py
@@ -29,6 +29,15 @@ y: address[2][2]
 
 def foo(x: num[2][2]) -> num:
     self.y = x
+    """,
+    """
+bar: num[3][3]
+
+def foo() -> num[3]:
+    self.bar = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    for x in self.bar:
+        if x == [4, 5, 6]:
+            return x
     """
 ]
 

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -240,6 +240,14 @@ class Context():
         self.placeholder_count = 1
         # Original code (for error pretty-printing purposes)
         self.origcode = origcode
+        # In Loop status. Wether body is currently evaluating within a for-loop or not.
+        self.in_for_loop = set()
+
+    def set_in_for_loop(self, name_of_list):
+        self.in_for_loop.add(name_of_list)
+
+    def remove_in_for_loop(self, name_of_list):
+        self.in_for_loop.remove(name_of_list)
 
     # Add a new variable
     def new_variable(self, name, typ):

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -222,7 +222,7 @@ class Stmt(object):
         subtype = iter_list_node.typ.subtype.typ
         varname = self.stmt.target.id
         value_pos = self.context.new_variable(varname, BaseType(subtype))
-        i_pos = self.context.new_variable('_i', BaseType(subtype))
+        i_pos = self.context.new_variable('_index_for_' + varname, BaseType(subtype))
 
         if iter_var_type:  # Is a list that is already allocated to memory.
             iter_var = self.context.vars.get(self.stmt.iter.id)

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -79,7 +79,7 @@ class Stmt(object):
             make_setter,
         )
 
-        if isinstance(self.stmt.targets[0], ast.Subscript):  # Check if we are doing assignment of an iteration loop.
+        if isinstance(self.stmt.targets[0], ast.Subscript) and self.context.in_for_loop:  # Check if we are doing assignment of an iteration loop.
             raise_exception = False
             if isinstance(self.stmt.targets[0].value, ast.Attribute):
                 list_name = "%s.%s" % (self.stmt.targets[0].value.value.id, self.stmt.targets[0].value.attr)

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -215,11 +215,10 @@ class Stmt(object):
             make_setter
         )
 
-        iter_var_type = self.context.vars.get(self.stmt.iter.id).typ if isinstance(self.stmt.iter, ast.Name) else None
-        if iter_var_type and not isinstance(iter_var_type.subtype, BaseType):  # Sanity check on list subtype.
-            raise StructureException('For loops allowed only on basetype lists.', self.stmt.iter)
-
         iter_list_node = Expr(self.stmt.iter, self.context).lll_node
+        if not isinstance(iter_list_node.typ.subtype, BaseType):  # Sanity check on list subtype.
+            raise StructureException('For loops allowed only on basetype lists.', self.stmt.iter)
+        iter_var_type = self.context.vars.get(self.stmt.iter.id).typ if isinstance(self.stmt.iter, ast.Name) else None
         subtype = iter_list_node.typ.subtype.typ
         varname = self.stmt.target.id
         value_pos = self.context.new_variable(varname, BaseType(subtype))

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -216,6 +216,7 @@ class Stmt(object):
             )
             return o
         else:
+            import ipdb; ipdb.set_trace()
             raise StructureException('For loop with list type not supported', self.stmt.iter)
 
     def aug_assign(self):


### PR DESCRIPTION
### - What I did

#438 
- Adds support for, `for i in list` syntax. Allowing you to iterate over lists.

### - How I did it
- Alter Stmt.parse_for, and added Stmt.parse_for_list function.

### - How to verify it

Check tests ;)

Something like this will work now:

```python
def data() -> num:
    s = [1, 2, 3, 4, 5, 6]
    for i in s:
        if i >= 3:
            return i
    return -1
```
### - Description for the changelog

Adds support foreach like for statements.

### - Cute Animal Picture
![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSpskv6iQYTOl8mZYdG8nSpcGhYfCudPo4kVSirvw-Ug7Qnic6pKQ)
