### PR TITLE
Add the packaging metadata to build the viper snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,41 @@
+name: viper
+version: git
+summary: Experimental language for the Ethereum Virtual Machine
+description: |
+  Viper is an experimental, contract-oriented, pythonic programming language that targets the Ethereum Virtual Machine (EVM)
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  viper:
+    command: viper
+
+parts:
+  viper:
+    source: .
+    plugin: python
+    python-version: python3
+    after: [python]
+  python:
+    source: https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz
+    plugin: autotools
+    configflags:
+      - --prefix=/usr
+    build-packages:
+      - gcc
+      - libreadline-dev
+      - libncursesw5-dev
+      - zlib1g-dev
+      - libbz2-dev
+      - liblzma-dev
+      - libgdbm-dev
+      - libdb-dev
+      - libssl-dev
+      - libexpat1-dev
+      - libmpdec-dev
+      - libbluetooth-dev
+      - libsqlite3-dev
+      - libffi-dev
+    stage:
+      - -usr/lib/python3.6/test


### PR DESCRIPTION
This package will let you publish the latest viper in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery. That will release every change in the master branch to the edge channel in the store, were it can be tested by early adopters before releasing to the stable channel.

### - What I did

A snap package for viper.

### - How I did it

Addinng the metadata file and running the snapcraft command.

### - How to verify it

In Ubuntu 16.04 or later, call snapcraft on the root of this branch.

### - Description for the changelog

Add the packaging metadata to build the viper snap

### - Cute Animal Picture

![photo4904470258664974293](https://user-images.githubusercontent.com/617831/32505840-c5ed5678-c3a8-11e7-8c9a-2fda1f5a2931.jpg)
