### PR TITLE
Remove tester ref from assert_tx_failed()

### DIFF
--- a/examples/stock/test_company.py
+++ b/examples/stock/test_company.py
@@ -19,7 +19,7 @@ def tester():
     return tester
 
 @pytest.fixture
-def assert_tx_failed(tester, function_to_test, exception = t.TransactionFailed):
+def assert_tx_failed(function_to_test, exception = t.TransactionFailed):
     initial_state = tester.s.snapshot()
     with pytest.raises(exception):
         function_to_test()
@@ -34,15 +34,15 @@ def test_overbuy(tester):
     assert tester.c.stock_available() == 0
     assert tester.c.get_holding(t.a1) == (test_shares * 2)
     one_stock = tester.c.get_price()
-    assert_tx_failed(tester, lambda: tester.c.buy_stock(sender=t.k1, value=one_stock))
-    assert_tx_failed(tester, lambda: tester.c.buy_stock(sender=t.k2, value=one_stock))
+    assert_tx_failed(lambda: tester.c.buy_stock(sender=t.k1, value=one_stock))
+    assert_tx_failed(lambda: tester.c.buy_stock(sender=t.k2, value=one_stock))
 
 def test_sell_without_stock(tester):
     # If you don't have any stock, you can't sell
-    assert_tx_failed(tester, lambda: tester.c.sell_stock(1, sender=t.k1))
-    assert_tx_failed(tester, lambda: tester.c.sell_stock(1, sender=t.k2))
+    assert_tx_failed(lambda: tester.c.sell_stock(1, sender=t.k1))
+    assert_tx_failed(lambda: tester.c.sell_stock(1, sender=t.k2))
     # Negative stock doesn't work either
-    assert_tx_failed(tester, lambda: tester.c.sell_stock(-1, sender=t.k1))
+    assert_tx_failed(lambda: tester.c.sell_stock(-1, sender=t.k1))
     # But if you do, you can!
     test_shares = int(tester.c.get_total_shares())
     test_value = int(test_shares * tester.c.get_price())
@@ -50,44 +50,44 @@ def test_sell_without_stock(tester):
     assert tester.c.get_holding(t.a1) == test_shares
     tester.c.sell_stock(test_shares, sender=t.k1)
     # But only until you run out
-    assert_tx_failed(tester, lambda: tester.c.sell_stock(1, sender=t.k1))
+    assert_tx_failed(lambda: tester.c.sell_stock(1, sender=t.k1))
 
 def test_oversell(tester):
     # You can't sell more than you own
     test_shares = int(tester.c.get_total_shares())
     test_value = int(test_shares * tester.c.get_price())
     tester.c.buy_stock(sender=t.k1, value=test_value)
-    assert_tx_failed(tester, lambda: tester.c.sell_stock(test_shares + 1, sender=t.k1))
+    assert_tx_failed(lambda: tester.c.sell_stock(test_shares + 1, sender=t.k1))
 
 def test_transfer(tester):
     # If you don't have any stock, you can't transfer
-    assert_tx_failed(tester, lambda: tester.c.transfer_stock(t.a2, 1, sender=t.k1))
-    assert_tx_failed(tester, lambda: tester.c.transfer_stock(t.a1, 1, sender=t.k2))
+    assert_tx_failed(lambda: tester.c.transfer_stock(t.a2, 1, sender=t.k1))
+    assert_tx_failed(lambda: tester.c.transfer_stock(t.a1, 1, sender=t.k2))
     # You can't do negative transfers to gain stock
-    assert_tx_failed(tester, lambda: tester.c.transfer_stock(t.a2, -1, sender=t.k1))
+    assert_tx_failed(lambda: tester.c.transfer_stock(t.a2, -1, sender=t.k1))
     # If you transfer, you don't have the stock anymore
     test_shares = int(tester.c.get_total_shares())
     test_value = int(test_shares * tester.c.get_price())
     tester.c.buy_stock(sender=t.k1, value=test_value)
     assert tester.c.get_holding(t.a1) == test_shares
     tester.c.transfer_stock(t.a2, test_shares, sender=t.k1)
-    assert_tx_failed(tester, lambda: tester.c.sell_stock(1, sender=t.k1))
+    assert_tx_failed(lambda: tester.c.sell_stock(1, sender=t.k1))
     # But the other person does
     tester.c.sell_stock(test_shares, sender=t.k2)
 
 def test_paybill(tester):
     # Only the company can authorize payments
-    assert_tx_failed(tester, lambda: tester.c.pay_bill(t.a2, 1, sender=t.k1))
+    assert_tx_failed(lambda: tester.c.pay_bill(t.a2, 1, sender=t.k1))
     # A company can only pay someone if it has the money
-    assert_tx_failed(tester, lambda: tester.c.pay_bill(t.a2, 1, sender=t.k0))
+    assert_tx_failed(lambda: tester.c.pay_bill(t.a2, 1, sender=t.k0))
     # If it has the money, it can pay someone
     test_value = int(tester.c.get_total_shares() * tester.c.get_price())
     tester.c.buy_stock(sender=t.k1, value=test_value)
     tester.c.pay_bill(t.a2, test_value, sender=t.k0)
     # Until it runs out of money
-    assert_tx_failed(tester, lambda: tester.c.pay_bill(t.a3, 1, sender=t.k0))
+    assert_tx_failed(lambda: tester.c.pay_bill(t.a3, 1, sender=t.k0))
     # Then no stockholders can sell their stock either
-    assert_tx_failed(tester, lambda: tester.c.sell_stock(1, sender=t.k1))
+    assert_tx_failed(lambda: tester.c.sell_stock(1, sender=t.k1))
 
 def test_valuation(tester):
     # Valuation is number of shares held times price

--- a/tests/examples/auctions/test_simple_open_auction.py
+++ b/tests/examples/auctions/test_simple_open_auction.py
@@ -16,7 +16,7 @@ def auction_tester():
 
 @pytest.fixture
 def assert_tx_failed():
-    def assert_tx_failed(tester, function_to_test, exception = tester.TransactionFailed):
+    def assert_tx_failed(function_to_test, exception = tester.TransactionFailed):
         initial_state = tester.s.snapshot()
         with pytest.raises(exception):
             function_to_test()
@@ -41,14 +41,14 @@ def test_initial_state(auction_tester):
 
 def test_bid(auction_tester, assert_tx_failed):
     # Bidder cannot bid 0
-    assert_tx_failed(auction_tester, lambda: auction_tester.c.bid(value=0, sender=auction_tester.k1))
+    assert_tx_failed(lambda: auction_tester.c.bid(value=0, sender=auction_tester.k1))
     # Bidder can bid
     auction_tester.c.bid(value=1, sender=tester.k1)
     # Check that higest bidder and highest bid have changed accordingly
     assert utils.remove_0x_head(auction_tester.c.get_highest_bidder()) == auction_tester.accounts[1].hex()
     assert auction_tester.c.get_highest_bid() == 1
     # Bidder bid cannot equal current highest bid
-    assert_tx_failed(auction_tester, lambda: auction_tester.c.bid(value=1, sender=auction_tester.k1))
+    assert_tx_failed(lambda: auction_tester.c.bid(value=1, sender=auction_tester.k1))
     # Higher bid can replace current highest bid
     auction_tester.c.bid(value=2, sender=tester.k2)
     # Check that higest bidder and highest bid have changed accordingly
@@ -71,7 +71,7 @@ def test_bid(auction_tester, assert_tx_failed):
 
 def test_auction_end(auction_tester, assert_tx_failed):
     # Fails if auction end time has not been reached
-    assert_tx_failed(auction_tester, lambda: auction_tester.c.auction_end())
+    assert_tx_failed(lambda: auction_tester.c.auction_end())
     auction_tester.c.bid(value=1 * 10**10, sender=tester.k2)
     # Move block timestamp foreward to reach auction end time
     auction_tester.s.head_state.timestamp += FIVE_DAYS
@@ -81,6 +81,6 @@ def test_auction_end(auction_tester, assert_tx_failed):
     # Beneficiary receives the highest bid
     assert balance_after_end == balance_before_end + 1 * 10 ** 10
     # Bidder cannot bid after auction end time has been reached
-    assert_tx_failed(auction_tester, lambda: auction_tester.c.bid(value=10, sender=auction_tester.k1))
+    assert_tx_failed(lambda: auction_tester.c.bid(value=10, sender=auction_tester.k1))
     # Auction cannot be ended twice
-    assert_tx_failed(auction_tester, lambda: auction_tester.c.auction_end())
+    assert_tx_failed(lambda: auction_tester.c.auction_end())

--- a/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
+++ b/tests/examples/safe_remote_purchase/test_safe_remote_purchase.py
@@ -33,7 +33,7 @@ def check_balance(tester):
 def test_initial_state(srp_tester, assert_tx_failed):
     assert check_balance(srp_tester) == [INIT_BAL, INIT_BAL]
     #Inital deposit has to be divisible by two
-    assert_tx_failed(srp_tester, lambda: srp_tester.s.contract(contract_code, language = "viper", args = [], value = 1))
+    assert_tx_failed(lambda: srp_tester.s.contract(contract_code, language = "viper", args = [], value = 1))
     #Seller puts item up for sale
     srp_tester.c = tester.s.contract(contract_code, language = "viper", args = [], value=2)
     #Check that the seller is set correctly
@@ -48,20 +48,20 @@ def test_initial_state(srp_tester, assert_tx_failed):
 def test_abort(srp_tester, assert_tx_failed):
     srp_tester.c = srp_tester.s.contract(contract_code, language = "viper", args = [], value=2)
     #Only sender can trigger refund
-    assert_tx_failed(srp_tester, lambda: srp_tester.c.abort(sender=srp_tester.k2))
+    assert_tx_failed(lambda: srp_tester.c.abort(sender=srp_tester.k2))
     #Refund works correctly
     srp_tester.c.abort(sender=srp_tester.k0)
     assert check_balance(srp_tester) == [INIT_BAL, INIT_BAL]
     #Purchase in process, no refund possible
     srp_tester.c = srp_tester.s.contract(contract_code, language = "viper", args = [], value=2)
     srp_tester.c.purchase(value=2, sender=srp_tester.k1)
-    assert_tx_failed(srp_tester, lambda: srp_tester.c.abort(sender=srp_tester.k0))
+    assert_tx_failed(lambda: srp_tester.c.abort(sender=srp_tester.k0))
     
 def test_purchase(srp_tester, assert_tx_failed):
     srp_tester.c = srp_tester.s.contract(contract_code, language = "viper", args = [], value=2)
     #Purchase for too low/high price
-    assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=1, sender=srp_tester.k1))
-    assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=3, sender=srp_tester.k1))
+    assert_tx_failed(lambda: srp_tester.c.purchase(value=1, sender=srp_tester.k1))
+    assert_tx_failed(lambda: srp_tester.c.purchase(value=3, sender=srp_tester.k1))
     #Purchase for the correct price 
     srp_tester.c.purchase(value=2, sender=srp_tester.k1)
     #Check if buyer is set correctly
@@ -71,16 +71,16 @@ def test_purchase(srp_tester, assert_tx_failed):
     #Check balances, both deposits should have been deducted
     assert check_balance(srp_tester) == [INIT_BAL-2, INIT_BAL-2]
     #Allow nobody else to purchase
-    assert_tx_failed(srp_tester, lambda: srp_tester.c.purchase(value=2, sender=srp_tester.k3))
+    assert_tx_failed(lambda: srp_tester.c.purchase(value=2, sender=srp_tester.k3))
 
 def test_received(srp_tester, assert_tx_failed):
     srp_tester.c = srp_tester.s.contract(contract_code, language = "viper", args = [], value=2)
     #Can only be called after purchase
-    assert_tx_failed(srp_tester, lambda: srp_tester.c.received(sender=srp_tester.k1))
+    assert_tx_failed(lambda: srp_tester.c.received(sender=srp_tester.k1))
     #Purchase completed
     srp_tester.c.purchase(value=2, sender=srp_tester.k1)
     #Check that e.g. sender cannot trigger received
-    assert_tx_failed(srp_tester, lambda: srp_tester.c.received(sender=srp_tester.k0))
+    assert_tx_failed(lambda: srp_tester.c.received(sender=srp_tester.k0))
     #Check if buyer can call receive
     srp_tester.c.received(sender=srp_tester.k1)
     #Final check if everything worked. 1 value has been transferred

--- a/tests/examples/tokens/test_vipercoin.py
+++ b/tests/examples/tokens/test_vipercoin.py
@@ -56,7 +56,6 @@ def test_transfer(token_tester, assert_tx_failed):
 
     # Negative transfer value.
     assert_tx_failed(
-        tester=token_tester,
         function_to_test=lambda: tester.c.transfer(token_tester.accounts[1], -1),
         exception=ValueOutOfBounds
     )
@@ -92,7 +91,6 @@ def test_transferFrom(token_tester, assert_tx_failed):
 
     # Negative transfer value.
     assert_tx_failed(
-        tester=token_tester,
         function_to_test=lambda: contract.transferFrom(a0, a2, -1, sender=k1),
         exception=ValueOutOfBounds
     )

--- a/tests/examples/wallet/test_wallet.py
+++ b/tests/examples/wallet/test_wallet.py
@@ -23,13 +23,13 @@ def test_approve(assert_tx_failed):
     to, value, data = b'\x35' * 20, 10**16, b""
     assert x.approve(0, to, value, data, [sign(0, to, value, data, k) if k else [0, 0, 0] for k in (t.k1, 0, t.k3, 0, t.k5)], value=value, sender=t.k1)
     # Approve fails if only 2 signatures are given
-    assert_tx_failed(t, lambda: x.approve(1, to, value, data, [sign(1, to, value, data, k) if k else [0, 0, 0] for k in (t.k1, 0, 0, 0, t.k5)], value=value, sender=t.k1))
+    assert_tx_failed(lambda: x.approve(1, to, value, data, [sign(1, to, value, data, k) if k else [0, 0, 0] for k in (t.k1, 0, 0, 0, t.k5)], value=value, sender=t.k1))
     # Approve fails if an invalid signature is given
-    assert_tx_failed(t, lambda: x.approve(1, to, value, data, [sign(1, to, value, data, k) if k else [0, 0, 0] for k in (t.k1, 0, t.k7, 0, t.k5)], value=value, sender=t.k1))
+    assert_tx_failed(lambda: x.approve(1, to, value, data, [sign(1, to, value, data, k) if k else [0, 0, 0] for k in (t.k1, 0, t.k7, 0, t.k5)], value=value, sender=t.k1))
     # Approve fails if transaction number is incorrect (the first argument should be 1)
-    assert_tx_failed(t, lambda: x.approve(0, to, value, data, [sign(0, to, value, data, k) if k else [0, 0, 0] for k in (t.k1, 0, t.k3, 0, t.k5)], value=value, sender=t.k1))
+    assert_tx_failed(lambda: x.approve(0, to, value, data, [sign(0, to, value, data, k) if k else [0, 0, 0] for k in (t.k1, 0, t.k3, 0, t.k5)], value=value, sender=t.k1))
     # Approve fails if not enough value is sent
-    assert_tx_failed(t, lambda: x.approve(1, to, value, data, [sign(1, to, value, data, k) if k else [0, 0, 0] for k in (t.k1, 0, t.k3, 0, t.k5)], value=0, sender=t.k1))
+    assert_tx_failed(lambda: x.approve(1, to, value, data, [sign(1, to, value, data, k) if k else [0, 0, 0] for k in (t.k1, 0, t.k3, 0, t.k5)], value=0, sender=t.k1))
     assert x.approve(1, to, value, data, [sign(1, to, value, data, k) if k else [0, 0, 0] for k in (t.k1, 0, t.k3, 0, t.k5)], value=value, sender=t.k1)
     print("Basic tests passed")
 

--- a/tests/parser/features/test_external_contract_calls.py
+++ b/tests/parser/features/test_external_contract_calls.py
@@ -225,8 +225,8 @@ def _expr(x: address) -> num:
 
     c2._stmt(c1.address)
     c2._expr(c1.address)
-    assert_tx_failed(t, lambda: c2._stmt(c2.address))
-    assert_tx_failed(t, lambda: c2._expr(c2.address))
+    assert_tx_failed(lambda: c2._stmt(c2.address))
+    assert_tx_failed(lambda: c2._expr(c2.address))
 
 
 def test_invalid_nonexistent_contract_call(assert_tx_failed):
@@ -248,8 +248,8 @@ def foo(x: address) -> num:
     t.s = s
 
     assert c2.foo(c1.address) == 1
-    assert_tx_failed(t, lambda: c2.foo(t.a1))
-    assert_tx_failed(t, lambda: c2.foo(t.a7))
+    assert_tx_failed(lambda: c2.foo(t.a1))
+    assert_tx_failed(lambda: c2.foo(t.a7))
 
 
 def test_invalid_contract_reference_declaration(assert_tx_failed):
@@ -263,7 +263,7 @@ def __init__():
     pass
 """
     t.s = t.Chain()
-    assert_tx_failed(t, lambda: get_contract(contract), exception = StructureException)
+    assert_tx_failed(lambda: get_contract(contract), exception = StructureException)
 
 
 def test_invalid_contract_reference_call(assert_tx_failed):
@@ -272,7 +272,7 @@ def bar(arg1: address, arg2: num) -> num:
     return Foo(arg1).foo(arg2)
 """
     t.s = t.Chain()
-    assert_tx_failed(t, lambda: get_contract(contract), exception = VariableDeclarationException)
+    assert_tx_failed(lambda: get_contract(contract), exception = VariableDeclarationException)
 
 
 def test_invalid_contract_reference_return_type(assert_tx_failed):
@@ -284,7 +284,7 @@ def bar(arg1: address, arg2: num) -> num:
     return Foo(arg1).foo(arg2)
 """
     t.s = t.Chain()
-    assert_tx_failed(t, lambda: get_contract(contract), exception = InvalidTypeException)
+    assert_tx_failed(lambda: get_contract(contract), exception = InvalidTypeException)
 
 
 def test_external_contracts_must_be_declared_first_1(assert_tx_failed):
@@ -296,7 +296,7 @@ class Foo():
     def foo(arg2: num) -> num: pass
 """
     t.s = t.Chain()
-    assert_tx_failed(t, lambda: get_contract(contract), exception = StructureException)
+    assert_tx_failed(lambda: get_contract(contract), exception = StructureException)
 
 
 def test_external_contracts_must_be_declared_first_2(assert_tx_failed):
@@ -308,7 +308,7 @@ class Foo():
     def foo(arg2: num) -> num: pass
 """
     t.s = t.Chain()
-    assert_tx_failed(t, lambda: get_contract(contract), exception = StructureException)
+    assert_tx_failed(lambda: get_contract(contract), exception = StructureException)
 
 
 def test_external_contracts_must_be_declared_first_3(assert_tx_failed):
@@ -321,4 +321,4 @@ class Foo():
     def foo(arg2: num) -> num: pass
 """
     t.s = t.Chain()
-    assert_tx_failed(t, lambda: get_contract(contract), exception = StructureException)
+    assert_tx_failed(lambda: get_contract(contract), exception = StructureException)

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -261,7 +261,7 @@ def foo_():
     log.MyLog('yo')
 """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract(loggy_code), TypeMismatchException)
+    assert_tx_failed(lambda: get_contract(loggy_code), TypeMismatchException)
 
 
 def test_fails_when_topic_is_the_wrong_size(assert_tx_failed):
@@ -271,7 +271,7 @@ def foo():
     log.MyLog('bars')
 """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract(loggy_code), TypeMismatchException)
+    assert_tx_failed(lambda: get_contract(loggy_code), TypeMismatchException)
 
 
 def test_fails_when_input_topic_is_the_wrong_size(assert_tx_failed):
@@ -281,7 +281,7 @@ def foo(arg1: bytes <= 4):
     log.MyLog(arg1)
 """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract(loggy_code), TypeMismatchException)
+    assert_tx_failed(lambda: get_contract(loggy_code), TypeMismatchException)
 
 
 def test_fails_when_data_is_the_wrong_size(assert_tx_failed):
@@ -291,7 +291,7 @@ def foo():
     log.MyLog('bars')
 """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract(loggy_code), TypeMismatchException)
+    assert_tx_failed(lambda: get_contract(loggy_code), TypeMismatchException)
 
 
 def test_fails_when_input_data_is_the_wrong_size(assert_tx_failed):
@@ -301,7 +301,7 @@ def foo(arg1: bytes <= 4):
     log.MyLog(arg1)
 """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract(loggy_code), TypeMismatchException)
+    assert_tx_failed(lambda: get_contract(loggy_code), TypeMismatchException)
 
 
 def test_fails_when_log_data_is_over_32_bytes(assert_tx_failed):
@@ -311,7 +311,7 @@ def foo():
     pass
     """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract(loggy_code), VariableDeclarationException)
+    assert_tx_failed(lambda: get_contract(loggy_code), VariableDeclarationException)
 
 
 def test_logging_fails_with_over_three_topics(assert_tx_failed):
@@ -321,7 +321,7 @@ def __init__():
     log.MyLog(1, 2, 3, 4)
     """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract_with_gas_estimation(loggy_code), VariableDeclarationException)
+    assert_tx_failed(lambda: get_contract_with_gas_estimation(loggy_code), VariableDeclarationException)
 
 
 def test_logging_fails_with_duplicate_log_names(assert_tx_failed):
@@ -333,7 +333,7 @@ def foo():
     log.MyLog()
     """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract_with_gas_estimation(loggy_code), VariableDeclarationException)
+    assert_tx_failed(lambda: get_contract_with_gas_estimation(loggy_code), VariableDeclarationException)
 
 
 def test_logging_fails_with_when_log_is_undeclared(assert_tx_failed):
@@ -342,7 +342,7 @@ def foo():
     log.MyLog()
     """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract_with_gas_estimation(loggy_code), VariableDeclarationException)
+    assert_tx_failed(lambda: get_contract_with_gas_estimation(loggy_code), VariableDeclarationException)
 
 
 def test_logging_fails_with_topic_type_mismatch(assert_tx_failed):
@@ -353,7 +353,7 @@ def foo():
     log.MyLog(self)
     """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract_with_gas_estimation(loggy_code), TypeMismatchException)
+    assert_tx_failed(lambda: get_contract_with_gas_estimation(loggy_code), TypeMismatchException)
 
 
 def test_logging_fails_with_data_type_mismatch(assert_tx_failed):
@@ -364,7 +364,7 @@ def foo():
     log.MyLog(self)
     """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract_with_gas_estimation(loggy_code), AttributeError)
+    assert_tx_failed(lambda: get_contract_with_gas_estimation(loggy_code), AttributeError)
 
 
 def test_logging_fails_after_a_global_declaration(assert_tx_failed):
@@ -373,7 +373,7 @@ age: num
 MyLog: __log__({arg1: bytes <= 3})
     """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract_with_gas_estimation(loggy_code), StructureException)
+    assert_tx_failed(lambda: get_contract_with_gas_estimation(loggy_code), StructureException)
 
 
 def test_logging_fails_after_a_function_declaration(assert_tx_failed):
@@ -384,7 +384,7 @@ def foo():
 MyLog: __log__({arg1: bytes <= 3})
     """
     t.s = s
-    assert_tx_failed(t, lambda: get_contract_with_gas_estimation(loggy_code), StructureException)
+    assert_tx_failed(lambda: get_contract_with_gas_estimation(loggy_code), StructureException)
 
 
 def test_loggy_code():

--- a/tests/parser/types/numbers/test_num256.py
+++ b/tests/parser/types/numbers/test_num256.py
@@ -40,19 +40,19 @@ def _num256_le(x: num256, y: num256) -> bool:
     assert c._num256_add(x, y) == x + y
     assert c._num256_add(0,y) == y
     assert c._num256_add(y,0) == y
-    assert_tx_failed(t, lambda: c._num256_add(NUM256_MAX, NUM256_MAX))
+    assert_tx_failed(lambda: c._num256_add(NUM256_MAX, NUM256_MAX))
     assert c._num256_sub(x, y) == x - y
-    assert_tx_failed(t, lambda: c._num256_sub(y, x))
+    assert_tx_failed(lambda: c._num256_sub(y, x))
     assert c._num256_sub(0, 0) == 0
     assert c._num256_sub(NUM256_MAX, 0) == NUM256_MAX
-    assert_tx_failed(t, lambda: c._num256_sub(1, 2))
+    assert_tx_failed(lambda: c._num256_sub(1, 2))
     assert c._num256_sub(NUM256_MAX, 1) == NUM256_MAX - 1
     assert c._num256_mul(x, y) == x * y
-    assert_tx_failed(t, lambda: c._num256_mul(NUM256_MAX, 2))
+    assert_tx_failed(lambda: c._num256_mul(NUM256_MAX, 2))
     assert c._num256_mul(NUM256_MAX, 0) == 0
     assert c._num256_mul(0, NUM256_MAX) == 0
     assert c._num256_div(x, y) == x // y
-    assert_tx_failed(t, lambda: c._num256_div(NUM256_MAX, 0))
+    assert_tx_failed(lambda: c._num256_div(NUM256_MAX, 0))
     assert c._num256_div(y, x) == 0
     assert c._num256_gt(x, y) is True
     assert c._num256_ge(x, y) is True
@@ -87,11 +87,11 @@ def _num256_mulmod(x: num256, y: num256, z: num256) -> num256:
     assert c._num256_addmod(1, 2, 2) == 1
     assert c._num256_addmod(32, 2, 32) == 2
     assert c._num256_addmod((2**256) - 1, 0, 2) == 1
-    assert_tx_failed(t, lambda: c._num256_addmod((2**256) - 1, 1, 1))
+    assert_tx_failed(lambda: c._num256_addmod((2**256) - 1, 1, 1))
     assert c._num256_mulmod(3, 1, 2) == 1
     assert c._num256_mulmod(200, 3, 601) == 600
     assert c._num256_mulmod(2**255, 1, 3) == 2
-    assert_tx_failed(t, lambda: c._num256_mulmod(2**255, 2, 1))
+    assert_tx_failed(lambda: c._num256_mulmod(2**255, 2, 1))
 
 
 def test_num256_with_exponents(assert_tx_failed):
@@ -106,7 +106,7 @@ def _num256_exp(x: num256, y: num256) -> num256:
     assert c._num256_exp(2, 0) == 1
     assert c._num256_exp(2, 1) == 2
     assert c._num256_exp(2, 3) == 8
-    assert_tx_failed(t, lambda: c._num256_exp(2**128, 2))
+    assert_tx_failed(lambda: c._num256_exp(2**128, 2))
     assert c._num256_exp(2**64, 2) == 2**128
     assert c._num256_exp(7**23, 3) == 7**69
 
@@ -131,13 +131,13 @@ def built_in_conversion(x: num256) -> num:
     assert c._num256_to_num(1) == 1
     assert c._num256_to_num((2**127) - 1) == 2**127 - 1
     t.s = s
-    assert_tx_failed(t, lambda: c._num256_to_num((2**128)) == 0)
+    assert_tx_failed(lambda: c._num256_to_num((2**128)) == 0)
     assert c._num256_to_num_call(1) == 1
 
     # Check that casting matches manual conversion
     assert c._num256_to_num_call(2**127 - 1) == c.built_in_conversion(2**127 - 1)
 
     # Pass in negative int.
-    assert_tx_failed(t, lambda: c._num256_to_num(-1) != -1, ValueOutOfBounds)
+    assert_tx_failed(lambda: c._num256_to_num(-1) != -1, ValueOutOfBounds)
     # Make sure it can't be coherced into a negative number.
-    assert_tx_failed(t, lambda: c._num256_to_num_call(2**127))
+    assert_tx_failed(lambda: c._num256_to_num_call(2**127))

--- a/tests/setup_transaction_tests.py
+++ b/tests/setup_transaction_tests.py
@@ -126,7 +126,7 @@ def get_last_log():
 
 @pytest.fixture
 def assert_tx_failed():
-    def assert_tx_failed(tester, function_to_test, exception = tester.TransactionFailed):
+    def assert_tx_failed(function_to_test, exception = tester.TransactionFailed):
         initial_state = tester.s.snapshot()
         with pytest.raises(exception):
             function_to_test()


### PR DESCRIPTION
### - What I did
I noticed that `assert_tx_failed()` fixture required a reference to `tester` that could just be referenced internally, fixing some usage issues people have been having. I wanted to also get rid of needing `lambda: ` but couldn't at this point

### - How I did it
Greped for all uses in `tests/` and updated `setup_transaction_tests.py`

### - How to verify it
Check out what tests I changed
Run pytest

### - Description for the changelog
Modified assert_tx_failed() to remove reference to tester as tester reference was already provided internally

### - Cute Animal Picture
![puma](https://i.ytimg.com/vi/oJfkFUxw768/maxresdefault.jpg)
