### PR TITLE
Fixes some gas estimates

### DIFF
--- a/bin/viper
+++ b/bin/viper
@@ -6,10 +6,13 @@ import viper
 
 from viper import compiler, optimizer
 from viper.parser.parser import parse_to_lll
+from viper.parser import parser_utils
+
 
 parser = argparse.ArgumentParser(description='Viper {0} programming language for Ethereum'.format(viper.__version__))
 parser.add_argument('input_file', help='Viper sourcecode to compile')
 parser.add_argument('-f', help='Format to print', choices=['abi', 'json', 'bytecode', 'ir'], default='bytecode', dest='format')
+parser.add_argument('--show-gas-estimates', help='Show gas estimates in ir output mode.', action="store_true")
 
 args = parser.parse_args()
 
@@ -17,6 +20,9 @@ if __name__ == '__main__':
 
     with open(args.input_file) as fh:
         code = fh.read()
+        if args.show_gas_estimates:
+            parser_utils.LLLnode.repr_show_gas = True
+
         if args.format == 'abi':
             print(compiler.mk_full_signature(code))
         elif args.format == 'json':

--- a/tests/parser/features/decorators/test_internal.py
+++ b/tests/parser/features/decorators/test_internal.py
@@ -13,7 +13,7 @@ def returnten() -> num:
     return self.a() * 2
     """
 
-    c = get_contract(internal_test)
+    c = get_contract_with_gas_estimation(internal_test)
     assert c.returnten() == 10
 
     print("Passed internal function test")

--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -31,7 +31,7 @@ def augmod(x: num, y: num) -> num:
     return z
     """
 
-    c = get_contract(augassign_test)
+    c = get_contract_with_gas_estimation(augassign_test)
 
     assert c.augadd(5, 12) == 17
     assert c.augmul(5, 12) == 60

--- a/tests/parser/features/test_clampers.py
+++ b/tests/parser/features/test_clampers.py
@@ -9,7 +9,7 @@ def foo(s: bytes <= 3) -> bytes <= 3:
     return s
     """
 
-    c = get_contract(clamper_test_code, value=1)
+    c = get_contract_with_gas_estimation(clamper_test_code, value=1)
     assert c.foo(b"ca") == b"ca"
     assert c.foo(b"cat") == b"cat"
     try:

--- a/tests/parser/features/test_gas.py
+++ b/tests/parser/features/test_gas.py
@@ -2,6 +2,9 @@ import pytest
 from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
     get_contract_with_gas_estimation, get_contract
 
+from viper.parser.parser import parse_to_lll
+from viper.parser import parser_utils
+
 
 def test_gas_call():
     gas_call = """
@@ -15,3 +18,17 @@ def foo() -> num:
     assert c.foo(startgas = 50000) < 50000
     assert c.foo(startgas = 50000) > 25000
     print('Passed gas test')
+
+
+def test_gas_estimate_repr():
+    code = """
+x: num
+
+
+def __init__():
+    self.x = 1
+    """
+    parser_utils.LLLnode.repr_show_gas = True
+    out = parse_to_lll(code)
+    assert str(out)[:30] == '\x1b[94m{\x1b[0m20303\x1b[94m} \x1b[0m[seq'
+    parser_utils.LLLnode.repr_show_gas = False

--- a/tests/parser/functions/test_is_contract.py
+++ b/tests/parser/functions/test_is_contract.py
@@ -14,14 +14,14 @@ def foo(arg1: address) -> bool:
 def foo(arg1: address) -> bool:
     return arg1.is_contract
 """
-    c1 = get_contract(contract_1)
-    c2 = get_contract(contract_2)
-    
-    assert c1.foo(c1.address) == True
-    assert c1.foo(c2.address) == True
-    assert c1.foo(t.a1) == False
-    assert c1.foo(t.a3) == False
-    assert c2.foo(c1.address) == True
-    assert c2.foo(c2.address) == True
-    assert c2.foo(t.a1) == False
-    assert c2.foo(t.a3) == False
+    c1 = get_contract_with_gas_estimation(contract_1)
+    c2 = get_contract_with_gas_estimation(contract_2)
+
+    assert c1.foo(c1.address) is True
+    assert c1.foo(c2.address) is True
+    assert c1.foo(t.a1) is False
+    assert c1.foo(t.a3) is False
+    assert c2.foo(c1.address) is True
+    assert c2.foo(c2.address) is True
+    assert c2.foo(t.a1) is False
+    assert c2.foo(t.a3) is False

--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -44,7 +44,7 @@ def out_very_long_bytes() -> (num, bytes <= 1024, num, address):
     return 5555, "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest", 6666, 0x0000000000000000000000000000000000001234  # noqa
     """
 
-    c = get_contract(code)
+    c = get_contract_with_gas_estimation(code)
 
     assert c.out() == [3333, "0x0000000000000000000000000000000000000001"]
     assert c.out_literals() == [1, "0x0000000000000000000000000000000000000000", b"random"]
@@ -62,5 +62,5 @@ def out_literals() -> (num, address, bytes <= 4):
     return 1, 0x0000000000000000000000000000000000000000, "random"
     """
 
-    c = get_contract(code)
+    c = get_contract_with_gas_estimation(code)
     assert c.translator.function_data['out_literals']['decode_types'] == ['int128', 'address', 'bytes']

--- a/tests/parser/globals/test_setters.py
+++ b/tests/parser/globals/test_setters.py
@@ -54,7 +54,7 @@ def jop() -> num:
 
     """
 
-    c = get_contract(multi_setter_test)
+    c = get_contract_with_gas_estimation(multi_setter_test)
     assert c.foo() == 321
     assert c.fop() == 654321
     assert c.goo() == 321
@@ -105,7 +105,7 @@ def gop() -> num:
         zed[1].bar[1].a * 1000000000000 + zed[1].bar[1].b * 10000000000000
     """
 
-    c = get_contract(multi_setter_struct_test)
+    c = get_contract_with_gas_estimation(multi_setter_struct_test)
     assert c.foo() == 654321
     assert c.fop() == 87198763254321
     assert c.goo() == 654321
@@ -130,7 +130,7 @@ def goo() -> num:
     return floor(self.pap[0][0] + self.pap[0][1] * 10 + self.pap[1][0] * 100 + self.pap[1][1] * 1000)
     """
 
-    c = get_contract(type_converter_setter_test)
+    c = get_contract_with_gas_estimation(type_converter_setter_test)
     assert c.foo() == 4321
     assert c.foo() == 4321
     print('Passed type-conversion struct test')
@@ -163,7 +163,7 @@ def foq() -> num:
     return popp.a[0].c + popp.a[1].c * 10 + popp.a[2].c * 100 + popp.b * 1000
     """
 
-    c = get_contract(composite_setter_test)
+    c = get_contract_with_gas_estimation(composite_setter_test)
     assert c.foo() == 4625
     assert c.fop() == 4625
     assert c.foq() == 4020

--- a/tests/parser/types/numbers/test_decimals.py
+++ b/tests/parser/types/numbers/test_decimals.py
@@ -49,7 +49,7 @@ def foop() -> num:
     return(floor(1999 % 1000.0))
     """
 
-    c = get_contract(decimal_test)
+    c = get_contract_with_gas_estimation(decimal_test)
     pre_txs = len(s.head_state.receipts)
     assert c.foo() == 999
     assert c.fop() == 999
@@ -97,7 +97,7 @@ def iarg() -> wei_value:
     x *= 2
     return x
     """
-    c = get_contract(harder_decimal_test)
+    c = get_contract_with_gas_estimation(harder_decimal_test)
     assert c.phooey(1.2) == 20736.0
     assert c.phooey(-1.2) == 20736.0
     assert c.arg(-3.7) == -3.7

--- a/tests/parser/types/numbers/test_num.py
+++ b/tests/parser/types/numbers/test_num.py
@@ -8,7 +8,7 @@ def _num_exp(x: num, y: num) -> num:
     return x**y
     """
 
-    c = get_contract(exp_code)
+    c = get_contract_with_gas_estimation(exp_code)
     assert c._num_exp(2,2) == 4
     assert c._num_exp(2,3) == 8
     assert c._num_exp(2,4) == 16

--- a/tests/parser/types/numbers/test_num256.py
+++ b/tests/parser/types/numbers/test_num256.py
@@ -31,7 +31,7 @@ def _num256_le(x: num256, y: num256) -> bool:
     return num256_le(x, y)
     """
 
-    c = get_contract(num256_code)
+    c = get_contract_with_gas_estimation(num256_code)
     x = 126416208461208640982146408124
     y = 7128468721412412459
 
@@ -100,7 +100,7 @@ def _num256_exp(x: num256, y: num256) -> num256:
         return num256_exp(x,y)
     """
 
-    c = get_contract(exp_code)
+    c = get_contract_with_gas_estimation(exp_code)
     t.s = s
 
     assert c._num256_exp(2, 0) == 1
@@ -123,7 +123,7 @@ def built_in_conversion(x: num256) -> num:
     return as_num128(x)
     """
 
-    c = get_contract(code)
+    c = get_contract_with_gas_estimation(code)
 
     # Ensure uint256 function signature.
     assert c.translator.function_data['_num256_to_num']['encode_types'] == ['uint256']

--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -9,7 +9,7 @@ def foo(x: bytes <= 100) -> bytes <= 100:
     return x
     """
 
-    c = get_contract(test_bytes)
+    c = get_contract_with_gas_estimation(test_bytes)
     moo_result = c.foo(b'cow')
     assert moo_result == b'cow'
 
@@ -35,7 +35,7 @@ def foo(x: bytes <= 100) -> bytes <= 100:
     return y
     """
 
-    c = get_contract(test_bytes2)
+    c = get_contract_with_gas_estimation(test_bytes2)
     assert c.foo(b'cow') == b'cow'
     assert c.foo(b'') == b''
     assert c.foo(b'\x35' * 63) == b'\x35' * 63
@@ -73,7 +73,7 @@ def get_xy() -> num:
     return self.x * self.y
     """
 
-    c = get_contract(test_bytes3)
+    c = get_contract_with_gas_estimation(test_bytes3)
     c.set_maa(b"pig")
     assert c.get_maa() == b"pig"
     assert c.get_maa2() == b"pig"
@@ -104,7 +104,7 @@ def bar(inp: bytes <= 60) -> bytes <= 60:
     return b
     """
 
-    c = get_contract(test_bytes4)
+    c = get_contract_with_gas_estimation(test_bytes4)
     assert c.foo() == b"", c.foo()
     assert c.bar() == b""
 
@@ -137,7 +137,7 @@ def quz(inp1: bytes <= 40, inp2: bytes <= 45):
     self.g = h
     """
 
-    c = get_contract(test_bytes5)
+    c = get_contract_with_gas_estimation(test_bytes5)
     c.foo(b"cow", b"horse")
     assert c.check1() == b"cow"
     assert c.check2() == b"horse"
@@ -156,7 +156,7 @@ def foo(x: bytes <= 32) -> num:
     return bytes_to_num(x)
     """
 
-    c = get_contract(bytes_to_num_code)
+    c = get_contract_with_gas_estimation(bytes_to_num_code)
     assert c.foo(b"") == 0
     try:
         c.foo(b"\x00")

--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -34,7 +34,7 @@ def loo(x: num[2][2]) -> num:
     return self.z2[0][0] + self.z2[0][1] + self.z3[0] * 10 + self.z3[1] * 10
     """
 
-    c = get_contract(list_tester_code)
+    c = get_contract_with_gas_estimation(list_tester_code)
     assert c.foo([3, 4, 5]) == 12
     assert c.goo([[1, 2], [3, 4]]) == 73
     assert c.hoo([3, 4, 5]) == 12
@@ -88,7 +88,7 @@ def roo(inp: num[2]) -> decimal[2][2]:
     return [inp,[3,4]]
     """
 
-    c = get_contract(list_output_tester_code)
+    c = get_contract_with_gas_estimation(list_output_tester_code)
     assert c.foo() == [3, 5]
     assert c.goo() == [3, 5]
     assert c.hoo() == [3, 5]

--- a/tests/parser/types/test_string_literal.py
+++ b/tests/parser/types/test_string_literal.py
@@ -25,7 +25,7 @@ def baz4() -> bytes <= 100:
                   "01234567890123456789012345678901234567890123456789")
     """
 
-    c = get_contract(string_literal_code)
+    c = get_contract_with_gas_estimation(string_literal_code)
     assert c.foo() == b"horse"
     assert c.bar() == b"badminton"
     assert c.baz() == b"012345678901234567890123456789012"
@@ -63,7 +63,7 @@ def baz(s: num, L: num) -> bytes <= 100:
         if x * y == 999:
             return self.moo
         """ % (("c" * i), ("c" * i), ("c" * i))
-        c = get_contract(kode)
+        c = get_contract_with_gas_estimation(kode)
         for e in range(63, 64, 65):
             for _s in range(31, 32, 33):
                 o1 = c.foo(_s, e - _s)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,7 +9,7 @@ def test_block_number():
 def block_number() -> num:
     return block.number
 """
-    c = get_contract(block_number_code)
+    c = get_contract_with_gas_estimation(block_number_code)
     c.block_number() == 2
 
 
@@ -150,7 +150,7 @@ def bar(inp1: bytes <= 10) -> num:
     return x * y
     """
 
-    c = get_contract(test_slice)
+    c = get_contract_with_gas_estimation(test_slice)
     x = c.foo(b"badminton")
     assert x == b"min", x
 
@@ -168,7 +168,7 @@ def slice_tower_test(inp1: bytes <= 50) -> bytes <= 50:
     return inp
     """
 
-    c = get_contract(test_slice2)
+    c = get_contract_with_gas_estimation(test_slice2)
     x = c.slice_tower_test(b"abcdefghijklmnopqrstuvwxyz1234")
     assert x == b"klmnopqrst", x
 
@@ -193,7 +193,7 @@ def bar(inp1: bytes <= 50) -> num:
     return self.x * self.y
     """
 
-    c = get_contract(test_slice3)
+    c = get_contract_with_gas_estimation(test_slice3)
     x = c.foo(b"badminton")
     assert x == b"min", x
 
@@ -208,7 +208,7 @@ def foo(inp: bytes <= 10, start: num, len: num) -> bytes <= 10:
     return slice(inp, start=start, len=len)
     """
 
-    c = get_contract(test_slice4)
+    c = get_contract_with_gas_estimation(test_slice4)
     assert c.foo(b"badminton", 3, 3) == b"min"
     assert c.foo(b"badminton", 0, 9) == b"badminton"
     assert c.foo(b"badminton", 1, 8) == b"adminton"
@@ -248,7 +248,7 @@ def foo(inp: bytes <= 10) -> num:
     return len(inp) * 100 + len(x) * 10 + len(self.y)
     """
 
-    c = get_contract(test_length)
+    c = get_contract_with_gas_estimation(test_length)
     assert c.foo(b"badminton") == 954, c.foo(b"badminton")
     print('Passed length test')
 
@@ -262,7 +262,7 @@ def foo3(input1: bytes <= 50, input2: bytes <= 50, input3: bytes <= 50) -> bytes
     return concat(input1, input2, input3)
     """
 
-    c = get_contract(test_concat)
+    c = get_contract_with_gas_estimation(test_concat)
     assert c.foo2(b"h", b"orse") == b"horse"
     assert c.foo2(b"h", b"") == b"h"
     assert c.foo2(b"", b"") == b""
@@ -281,7 +281,7 @@ def foo(inp: bytes <= 50) -> bytes <= 1000:
     return concat(x, inp, x, inp, x, inp, x, inp, x, inp)
     """
 
-    c = get_contract(test_concat2)
+    c = get_contract_with_gas_estimation(test_concat2)
     assert c.foo(b"horse" * 9 + b"viper") == (b"horse" * 9 + b"viper") * 10
     print('Passed second concat test')
 
@@ -296,7 +296,7 @@ def krazykonkat(z: bytes <= 10) -> bytes <= 25:
     return concat(x, " ", self.y, " ", z)
     """
 
-    c = get_contract(crazy_concat_code)
+    c = get_contract_with_gas_estimation(crazy_concat_code)
 
     assert c.krazykonkat(b"moose") == b'cow horse moose'
 
@@ -312,7 +312,7 @@ def bar() -> bytes32:
     return sha3("inp")
     """
 
-    c = get_contract(hash_code)
+    c = get_contract_with_gas_estimation(hash_code)
     for inp in (b"", b"cow", b"s" * 31, b"\xff" * 32, b"\n" * 33, b"g" * 64, b"h" * 65):
         assert c.foo(inp) == u.sha3(inp)
 
@@ -324,7 +324,7 @@ def test_hash_code2():
 def foo(inp: bytes <= 100) -> bool:
     return sha3(inp) == sha3("badminton")
     """
-    c = get_contract(hash_code2)
+    c = get_contract_with_gas_estimation(hash_code2)
     assert c.foo(b"badminto") is False
     assert c.foo(b"badminton") is True
 
@@ -345,7 +345,7 @@ def trymem(inp: bytes <= 100) -> bool:
 def try32(inp: bytes32) -> bool:
     return sha3(inp) == sha3(self.test)
     """
-    c = get_contract(hash_code3)
+    c = get_contract_with_gas_estimation(hash_code3)
     c.set_test(b"")
     assert c.tryy(b"") is True
     assert c.trymem(b"") is True
@@ -376,7 +376,7 @@ def returnten() -> num:
     ans = raw_call(self, concat(method_id("double(int128)"), as_bytes32(5)), gas=50000, outsize=32)
     return as_num128(extract32(ans, 0))
     """
-    c = get_contract(method_id_test)
+    c = get_contract_with_gas_estimation(method_id_test)
     assert c.returnten() == 10
     print("Passed method ID test")
 
@@ -393,7 +393,7 @@ def test_ecrecover2() -> address:
                      as_num256(6577251522710269046055727877571505144084475024240851440410274049870970796685))
     """
 
-    c = get_contract(ecrecover_test)
+    c = get_contract_with_gas_estimation(ecrecover_test)
     h = b'\x35' * 32
     k = b'\x46' * 32
     v, r, S = u.ecsign(h, k)
@@ -462,7 +462,7 @@ def fivetimes(inp: bytes32) -> bytes <= 160:
     return concat(inp, inp, inp, inp, inp)
     """
 
-    c = get_contract(test_concat_bytes32)
+    c = get_contract_with_gas_estimation(test_concat_bytes32)
     assert c.sandwich(b"cow", b"\x35" * 32) == b"\x35" * 32 + b"cow" + b"\x35" * 32, c.sandwich(b"cow", b"\x35" * 32)
     assert c.sandwich(b"", b"\x46" * 32) == b"\x46" * 64
     assert c.sandwich(b"\x57" * 95, b"\x57" * 32) == b"\x57" * 159
@@ -485,7 +485,7 @@ def baz() -> bytes <= 7:
     return raw_call(0x0000000000000000000000000000000000000004, "moose", gas=50000, outsize=7)
     """
 
-    c = get_contract(caller_code)
+    c = get_contract_with_gas_estimation(caller_code)
     assert c.foo() == b"moose"
     assert c.bar() == b"moo"
     assert c.baz() == b"moose\x00\x00"
@@ -511,7 +511,7 @@ def foq(inp: bytes <= 32) -> address:
     return extract32(inp, 0, type=address)
     """
 
-    c = get_contract(extract32_code)
+    c = get_contract_with_gas_estimation(extract32_code)
     assert c.foo(b"\x00" * 30 + b"\x01\x01") == 257
     assert c.bar(b"\x00" * 30 + b"\x01\x01") == 257
     try:
@@ -587,7 +587,7 @@ def voo(inp: bytes <= 1024) -> num:
     x = RLPList(inp, [num, num, bytes32, num, bytes32, bytes])
     return x[1]
     """
-    c = get_contract(rlp_decoder_code)
+    c = get_contract_with_gas_estimation(rlp_decoder_code)
 
     assert c.foo() == '0x' + '35' * 20
     assert c.fop() == b'G' * 32
@@ -660,7 +660,7 @@ def hoo(x: bytes32, y: bytes32) -> bytes <= 64:
     return concat(x, y)
     """
 
-    c = get_contract(konkat_code)
+    c = get_contract_with_gas_estimation(konkat_code)
     assert c.foo(b'\x35' * 32, b'\x00' * 32) == b'\x35' * 32 + b'\x00' * 32
     assert c.goo(b'\x35' * 32, b'\x00' * 32) == b'\x35' * 32 + b'\x00' * 32
     assert c.hoo(b'\x35' * 32, b'\x00' * 32) == b'\x35' * 32 + b'\x00' * 32
@@ -694,9 +694,9 @@ def foo() -> num:
     return 5
     """
 
-    c = get_contract(large_input_code_2, args=[17], sender=t.k0, value=0)
+    c = get_contract_with_gas_estimation(large_input_code_2, args=[17], sender=t.k0, value=0)
     try:
-        c = get_contract(large_input_code_2, args=[2**130], sender=t.k0, value=0)
+        c = get_contract_with_gas_estimation(large_input_code_2, args=[2**130], sender=t.k0, value=0)
         success = True
     except:
         success = False
@@ -726,7 +726,7 @@ def _shift(x: num256, y: num) -> num256:
     return shift(x, y)
     """
 
-    c = get_contract(test_bitwise)
+    c = get_contract_with_gas_estimation(test_bitwise)
     x = 126416208461208640982146408124
     y = 7128468721412412459
     assert c._bitwise_and(x, y) == (x & y)
@@ -760,7 +760,7 @@ def returnten() -> num:
     return self._len("badminton!")
     """
 
-    c = get_contract(selfcall_code_3)
+    c = get_contract_with_gas_estimation(selfcall_code_3)
     assert c.return_hash_of_cow_x_30() == u.sha3(b'cow' * 30)
     assert c.returnten() == 10
 
@@ -773,7 +773,7 @@ def returnten() -> num:
     return 10
     """
 
-    c = get_contract(inner_code)
+    c = get_contract_with_gas_estimation(inner_code)
 
     outer_code = """
 def create_and_call_returnten(inp: address) -> num:
@@ -836,7 +836,7 @@ def goo() -> num256:
     return num256_add(min(as_num256(3), as_num256(5)), max(as_num256(40), as_num256(80)))
     """
 
-    c = get_contract(minmax_test)
+    c = get_contract_with_gas_estimation(minmax_test)
     assert c.foo() == 58223.123
     assert c.goo() == 83
 
@@ -846,7 +846,7 @@ def test_ecadd():
     ecadder = """
 x3: num256[2]
 y3: num256[2]
-    
+
 def _ecadd(x: num256[2], y: num256[2]) -> num256[2]:
     return ecadd(x, y)
 
@@ -861,7 +861,7 @@ def _ecadd3(x: num256[2], y: num256[2]) -> num256[2]:
     return ecadd(self.x3, self.y3)
 
     """
-    c = get_contract(ecadder)
+    c = get_contract_with_gas_estimation(ecadder)
 
     assert c._ecadd(G1, G1) == G1_times_two
     assert c._ecadd2(G1, G1_times_two) == G1_times_three
@@ -872,7 +872,7 @@ def test_ecmul():
     ecmuller = """
 x3: num256[2]
 y3: num256
-    
+
 def _ecmul(x: num256[2], y: num256) -> num256[2]:
     return ecmul(x, y)
 
@@ -887,7 +887,7 @@ def _ecmul3(x: num256[2], y: num256) -> num256[2]:
     return ecmul(self.x3, self.y3)
 
 """
-    c = get_contract(ecmuller)
+    c = get_contract_with_gas_estimation(ecmuller)
 
     assert c._ecmul(G1, 0) == [0 ,0]
     assert c._ecmul(G1, 1) == G1
@@ -906,6 +906,6 @@ def exp(base: num256, exponent: num256, modulus: num256) -> num256:
       return o
     """
 
-    c = get_contract(modexper)
+    c = get_contract_with_gas_estimation(modexper)
     assert c.exp(3, 5, 100) == 43
     assert c.exp(2, 997, 997) == 2

--- a/viper/opcodes.py
+++ b/viper/opcodes.py
@@ -71,11 +71,11 @@ opcodes = {
 }
 
 pseudo_opcodes = {
-    'CLAMP': [None, 3, 1, 45 + 25],
+    'CLAMP': [None, 3, 1, 70],
     'UCLAMPLT': [None, 2, 1, 25],
     'UCLAMPLE': [None, 2, 1, 30],
     'CLAMP_NONZERO': [None, 1, 1, 19],
-    'ASSERT': [None, 1, 0, 20 + 65],
+    'ASSERT': [None, 1, 0, 85],
     'PASS': [None, 0, 0, 0],
     'BREAK': [None, 0, 0, 20],
     'SHA3_32': [None, 1, 1, 72],

--- a/viper/opcodes.py
+++ b/viper/opcodes.py
@@ -71,11 +71,11 @@ opcodes = {
 }
 
 pseudo_opcodes = {
-    'CLAMP': [None, 3, 1, 45],
+    'CLAMP': [None, 3, 1, 45 + 25],
     'UCLAMPLT': [None, 2, 1, 25],
     'UCLAMPLE': [None, 2, 1, 30],
     'CLAMP_NONZERO': [None, 1, 1, 19],
-    'ASSERT': [None, 1, 0, 20],
+    'ASSERT': [None, 1, 0, 20 + 65],
     'PASS': [None, 0, 0, 0],
     'BREAK': [None, 0, 0, 20],
     'SHA3_32': [None, 1, 1, 72],

--- a/viper/parser/parser_utils.py
+++ b/viper/parser/parser_utils.py
@@ -129,7 +129,7 @@ class LLLnode():
             # Seq statements: seq <statement> <statement> ...
             elif self.value == 'seq':
                 self.valency = self.args[-1].valency if self.args else 0
-                self.gas = sum([arg.gas for arg in self.args])
+                self.gas = sum([arg.gas for arg in self.args]) + 30
             # Multi statements: multi <expr> <expr> ...
             elif self.value == 'multi':
                 for arg in self.args:


### PR DESCRIPTION
### - What I did

- Added --show-gas-estimates to work with -f ir; this was really helpful in for to figure out what is going on with the gas estimates on the LLL level. So I figured it can be added for more improvement ;)
- Replaced get_contract with get_contract_with_gas_estimation in most places, internal/external call tests abd RLPList are still outstanding, but are perfect for another PR (this one is quite a number of changes already).

### - How I did it

Started replacing get_contract with get_contract_with_gas_estimation. Starting at the LLL, checking the gas estimate tree and then a bit of trial and error on each test cases the subsequently failed.

### - How to verify it
Run the tests, and check out --show-gas-estimates..
![image](https://user-images.githubusercontent.com/6917456/32601640-010f02b6-c54c-11e7-8beb-ce0624f1c699.png)

### - Description for the changelog

Improved gas estimates.

### - Cute Animal Picture

![](http://cdn3-www.dogtime.com/assets/uploads/gallery/30-impossibly-cute-puppies/impossibly-cute-puppy-21.jpg)
