### PR TITLE
fix issue #448: buggy translation of LLL operator `sha3_32`

### DIFF
--- a/tests/compiler/test_sha3_32.py
+++ b/tests/compiler/test_sha3_32.py
@@ -1,0 +1,9 @@
+import pytest
+from viper.parser.parser_utils import LLLnode
+from viper import compile_lll, optimizer
+
+def test_sha3_32():
+    lll = ['sha3_32', 0]
+    evm = ['PUSH1', 0, 'PUSH1', 192, 'MSTORE', 'PUSH1', 32, 'PUSH1', 192, 'SHA3']
+    assert compile_lll.compile_to_assembly(LLLnode.from_list(lll)) == evm
+    assert compile_lll.compile_to_assembly(optimizer.optimize(LLLnode.from_list(lll))) == evm

--- a/viper/compile_lll.py
+++ b/viper/compile_lll.py
@@ -204,7 +204,7 @@ def compile_to_assembly(code, withargs=None, break_dest=None, height=0):
     # SHA3 a single value
     elif code.value == 'sha3_32':
         o = compile_to_assembly(code.args[0], withargs, break_dest, height)
-        o.extend(['PUSH1', MemoryPositions.FREE_VAR_SPACE, 'MSTORE', 'PUSH1', MemoryPositions.FREE_VAR_SPACE, 'PUSH1', 32, 'SHA3'])
+        o.extend(['PUSH1', MemoryPositions.FREE_VAR_SPACE, 'MSTORE', 'PUSH1', 32, 'PUSH1', MemoryPositions.FREE_VAR_SPACE, 'SHA3'])
         return o
     # <= operator
     elif code.value == 'le':


### PR DESCRIPTION
### - What I did

Fix issue #448: compile_lll.py: buggy translation of LLL operator `sha3_32`

### - How I did it

As suggested in #448.

### - How to verify it

Look over the change made and verify that all tests are still passing.

### - Description for the change log

None

### - Cute Animal Picture

```
               __   __
              __ \ / __
             /  \ | /  \
                 \|/
            _,.---v---._
   /\__/\  /            \
   \_  _/ /              \
     \ \_|           @ __|
  hjw \                \_
  `97  \     ,__/       /
     ~~~`~~~~~~~~~~~~~~/~~~~
```
