### PR TITLE
Fix issue #450: buggy translation of constant clamp expressions

### DIFF
--- a/tests/compiler/test_clamps.py
+++ b/tests/compiler/test_clamps.py
@@ -1,0 +1,97 @@
+import pytest
+
+
+def test_uclamplt(t, get_contract_from_lll, assert_compile_failed):
+    lll = ['uclamplt', 2, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclamplt', 1, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclamplt', 0, 1]
+    get_contract_from_lll(lll)
+
+
+def test_uclample(t, get_contract_from_lll, assert_compile_failed):
+    lll = ['uclample', 2, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclample', 1, 1]
+    get_contract_from_lll(lll)
+    lll = ['uclample', 0, 1]
+    get_contract_from_lll(lll)
+
+
+def test_uclampgt(t, get_contract_from_lll, assert_compile_failed):
+    lll = ['uclampgt', 1, 2]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclampgt', 1, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclampgt', 1, 0]
+    get_contract_from_lll(lll)
+
+
+def test_uclampge(t, get_contract_from_lll, assert_compile_failed):
+    lll = ['uclampge', 1, 2]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclampge', 1, 1]
+    get_contract_from_lll(lll)
+    lll = ['uclampge', 1, 0]
+    get_contract_from_lll(lll)
+
+
+def test_uclamplt_and_clamplt(t, get_contract_from_lll, assert_compile_failed):
+    lll = ['uclamplt', 2, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclamplt', 1, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclamplt', 0, 1]
+    get_contract_from_lll(lll)
+    lll = ['clamplt', 2, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['clamplt', 1, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['clamplt', 0, 1]
+    get_contract_from_lll(lll)
+
+
+def test_uclample_clample(t, get_contract_from_lll, assert_compile_failed):
+    lll = ['uclample', 2, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclample', 1, 1]
+    get_contract_from_lll(lll)
+    lll = ['uclample', 0, 1]
+    get_contract_from_lll(lll)
+    lll = ['clample', 2, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['clample', 1, 1]
+    get_contract_from_lll(lll)
+    lll = ['clample', 0, 1]
+    get_contract_from_lll(lll)
+
+
+def test_uclampgt_and_clampgt(t, get_contract_from_lll, assert_compile_failed):
+    lll = ['uclampgt', 1, 2]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclampgt', 1, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclampgt', 1, 0]
+    get_contract_from_lll(lll)
+    lll = ['clampgt', 1, 2]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['clampgt', 1, 1]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['clampgt', 1, 0]
+    get_contract_from_lll(lll)
+
+
+def test_uclampge_and_clampge(t, get_contract_from_lll, assert_compile_failed):
+    lll = ['uclampge', 1, 2]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['uclampge', 1, 1]
+    get_contract_from_lll(lll)
+    lll = ['uclampge', 1, 0]
+    get_contract_from_lll(lll)
+    lll = ['clampge', 1, 2]
+    assert_compile_failed(lambda: get_contract_from_lll(lll), Exception)
+    lll = ['clampge', 1, 1]
+    get_contract_from_lll(lll)
+    lll = ['clampge', 1, 0]
+    get_contract_from_lll(lll)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from viper import (
     compile_lll,
     optimizer
 )
+from tests.setup_transaction_tests import assert_tx_failed
 
 @pytest.fixture
 def bytes_helper():
@@ -26,3 +27,7 @@ def get_contract_from_lll(t):
         byte_code = compile_lll.assembly_to_evm(compile_lll.compile_to_assembly(lll))
         t.s.tx(to=b'', data=byte_code)
     return lll_compiler
+
+@pytest.fixture
+def assert_compile_failed(assert_tx_failed):
+    return assert_tx_failed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,28 @@
 import pytest
+from ethereum.tools import tester
+from viper.parser.parser_utils import (
+    LLLnode
+)
+from viper import (
+    compile_lll,
+    optimizer
+)
 
 @pytest.fixture
 def bytes_helper():
     def bytes_helper(str, length):
         return bytes(str, 'utf-8') + bytearray(length-len(str))
     return bytes_helper
+
+@pytest.fixture
+def t():
+    tester.s = tester.Chain()
+    return tester
+
+@pytest.fixture
+def get_contract_from_lll(t):
+    def lll_compiler(lll):
+        lll = optimizer.optimize(LLLnode.from_list(lll))
+        byte_code = compile_lll.assembly_to_evm(compile_lll.compile_to_assembly(lll))
+        t.s.tx(to=b'', data=byte_code)
+    return lll_compiler


### PR DESCRIPTION
### - What I did
Fixed clamps in `compile_lll.py`
Added a fixture to make it easier to test `LLL`
Created `LLL` clamp tests
In response to issue #450, thanks @daejunpark

### - How I did it
Corrected clamp constant checks in `compile_lll.py` 

### - How to verify it
Look at the tests I created in `tests/compiler/test_clamps.py`.
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/32694354-da16dc5a-c6fa-11e7-81f8-a1ee9c740c1e.png)

