### PR TITLE
Fix issue #451: buggy translation of `repeat` when #iteration <= 0

### DIFF
--- a/tests/compiler/LLL/test_repeat.py
+++ b/tests/compiler/LLL/test_repeat.py
@@ -1,0 +1,9 @@
+import pytest
+
+def test_repeat(t, get_contract_from_lll, assert_compile_failed):
+    good_lll = ['repeat', 0, 0, 1, ['seq']]
+    bad_lll_1 = ['repeat', 0, 0, 0, ['seq']]
+    bad_lll_2 = ['repeat', 0, 0, -1, ['seq']]
+    get_contract_from_lll(good_lll)
+    assert_compile_failed(lambda: get_contract_from_lll(bad_lll_1), Exception)
+    assert_compile_failed(lambda: get_contract_from_lll(bad_lll_2), Exception)

--- a/viper/compile_lll.py
+++ b/viper/compile_lll.py
@@ -93,7 +93,9 @@ def compile_to_assembly(code, withargs=None, break_dest=None, height=0):
     # Repeat(memloc, start, rounds, body)
     elif code.value == 'repeat':
         o = []
-        loops = num_to_bytearray(code.args[2].value) or [2]
+        loops = num_to_bytearray(code.args[2].value)
+        if not loops:
+            raise Exception("Number of times repeated must be a constant nonzero positive integer: %r" % loops)
         start, end = mksymbol(), mksymbol()
         o.extend(compile_to_assembly(code.args[0], withargs, break_dest, height))
         o.extend(compile_to_assembly(code.args[1], withargs, break_dest, height + 1))


### PR DESCRIPTION
### - What I did
Fix `repeat` LLL in `compile_lll.py` so that it throws if `iteration_count <= 0`
Fixes #451, thanks @daejunpark
### - How I did it
Added a conditional the checks for invalid iteration counts
### - How to verify it
Look at the code I changed
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/32694374-7d0abfb2-c6fb-11e7-9f75-a0b8e696ca23.png)

