### PR TITLE
Fix issue #449: inconsistency in checking invalid cases

### DIFF
--- a/tests/compiler/LLL/test_with.py
+++ b/tests/compiler/LLL/test_with.py
@@ -1,0 +1,36 @@
+import pytest
+
+def test_with_depth(t, get_contract_from_lll, assert_compile_failed):
+    _16_with_statements=['with', 'var_1', 0,
+                        ['with', 'var_2', 0,
+                        ['with', 'var_3', 0,
+                        ['with', 'var_4', 0,
+                        ['with', 'var_5', 0,
+                        ['with', 'var_6', 0,
+                        ['with', 'var_7', 0,
+                        ['with', 'var_8', 0,
+                        ['with', 'var_9', 0,
+                        ['with', 'var_10', 0,
+                        ['with', 'var_11', 0,
+                        ['with', 'var_12', 0,
+                        ['with', 'var_13', 0,
+                        ['with', 'var_14', 0,
+                        ['with', 'var_15', 0, ['mstore', 'var_1', 1]]]]]]]]]]]]]]]]
+    _17_with_statements=['with', 'var_1', 0,
+                        ['with', 'var_2', 0,
+                        ['with', 'var_3', 0,
+                        ['with', 'var_4', 0,
+                        ['with', 'var_5', 0,
+                        ['with', 'var_6', 0,
+                        ['with', 'var_7', 0,
+                        ['with', 'var_8', 0,
+                        ['with', 'var_9', 0,
+                        ['with', 'var_10', 0,
+                        ['with', 'var_11', 0,
+                        ['with', 'var_12', 0,
+                        ['with', 'var_13', 0,
+                        ['with', 'var_14', 0,
+                        ['with', 'var_15', 0,
+                        ['with', 'var_16', 0, ['mstore', 'var_1', 1]]]]]]]]]]]]]]]]]
+    get_contract_from_lll(_16_with_statements)
+    assert_compile_failed(lambda: get_contract_from_lll(_17_with_statements), Exception)

--- a/viper/compile_lll.py
+++ b/viper/compile_lll.py
@@ -54,6 +54,8 @@ def compile_to_assembly(code, withargs=None, break_dest=None, height=0):
         return ['DUP' + str(height - withargs[code.value])]
     # Setting variables connected to with statements
     elif code.value == "set":
+        if height - withargs[code.args[0].value] > 16:
+            raise Exception("With statement too deep")
         if len(code.args) != 2 or code.args[0].value not in withargs:
             raise Exception("Set expects two arguments, the first being a stack variable")
         return compile_to_assembly(code.args[1], withargs, break_dest, height) + \


### PR DESCRIPTION
### - What I did
Fix `with` statement error in `compile_lll.py` which led to `SWAP17` turning into `LOG0` (because `SWAP17` doesn't exist)
Fixes issue #449, thanks @daejunpark 
### - How I did it
Added a conditional that throws with a with statement that's too deep.
### - How to verify it
Look at the code I added
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/32694479-0629d3ee-c6fe-11e7-9354-ae8d845a0f63.png)


