### PR TITLE
Improve rlp list gas estimation

### DIFF
--- a/viper/functions.py
+++ b/viper/functions.py
@@ -597,7 +597,7 @@ def _RLPlist(expr, args, kwargs, context):
         ['seq',
             ['with', '_sub', variable_pointer,
                 ['pop', ['call',
-                         10000 + 500 * len(_format) + 10 * len(args),
+                         1500 + 400 * len(_format) + 10 * len(args),
                          LLLnode.from_list(RLP_DECODER_ADDRESS, annotation='RLP decoder'),
                          0,
                          ['add', '_sub', 32],


### PR DESCRIPTION
### - What I did
Get `RLPlist` function's `gas_estimate` closer to the actual amount of gas used.
### - How I did it
Kept reducing the `gas_estimate` without allowing it to go under the actual amount of gas used.

### - How to verify it
Look over the gas numbers I changed for `_RLPlist` in `functions.py`
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/32754865-dcc1a6f6-c88f-11e7-9e7c-a095171f47e6.png)

