### PR TITLE
Require function visibility declaration

### DIFF
--- a/examples/auctions/simple_open_auction.v.py
+++ b/examples/auctions/simple_open_auction.v.py
@@ -16,6 +16,7 @@ ended: public(bool)
 # Create a simple auction with `_bidding_time`
 # seconds bidding time on behalf of the
 # beneficiary address `_beneficiary`.
+@public
 def __init__(_beneficiary: address, _bidding_time: timedelta):
     self.beneficiary = _beneficiary
     self.auction_start = block.timestamp
@@ -25,6 +26,7 @@ def __init__(_beneficiary: address, _bidding_time: timedelta):
 # together with this transaction.
 # The value will only be refunded if the
 # auction is not won.
+@public
 @payable
 def bid():
     # Check if bidding period is over.
@@ -40,6 +42,7 @@ def bid():
 
 # End the auction and send the highest bid
 # to the beneficiary.
+@public
 def auction_end():
     # It is a good guideline to structure functions that interact
     # with other contracts (i.e. they call functions or send Ether)

--- a/examples/crowdfund.v.py
+++ b/examples/crowdfund.v.py
@@ -7,6 +7,7 @@ refundIndex: num
 timelimit: timedelta
 
 # Setup global variables
+@public
 def __init__(_beneficiary: address, _goal: wei_value, _timelimit: timedelta):
     self.beneficiary = _beneficiary
     self.deadline = block.timestamp + _timelimit
@@ -14,6 +15,7 @@ def __init__(_beneficiary: address, _goal: wei_value, _timelimit: timedelta):
     self.goal = _goal
 
 # Participate in this crowdfunding campaign
+@public
 @payable
 def participate():
     assert block.timestamp < self.deadline
@@ -22,12 +24,14 @@ def participate():
     self.nextFunderIndex = nfi + 1
 
 # Enough money was raised! Send funds to the beneficiary
+@public
 def finalize():
     assert block.timestamp >= self.deadline and self.balance >= self.goal
     selfdestruct(self.beneficiary)
 
 # Not enough money was raised! Refund everyone (max 30 people at a time
 # to avoid gas limit issues)
+@public
 def refund():
     assert block.timestamp >= self.deadline and self.balance < self.goal
     ind = self.refundIndex

--- a/examples/safe_remote_purchase/safe_remote_purchase.v.py
+++ b/examples/safe_remote_purchase/safe_remote_purchase.v.py
@@ -15,25 +15,29 @@ unlocked: public(bool)
 #def unlocked() -> bool: #Is a refund possible for the seller?
 #    return (self.balance == self.value*2)
 #    
+@public
 @payable
 def __init__():
     assert (msg.value % 2) == 0
     self.value = msg.value / 2 #Seller initializes contract by posting a safety deposit of 2*value of the item up for sale
     self.seller = msg.sender
     self.unlocked = true
-    
+
+@public
 def abort():
     assert self.unlocked #Is the contract still refundable
     assert msg.sender == self.seller #Only seller can refund his deposit before any buyer purchases the item
     selfdestruct(self.seller) #Refunds seller, deletes contract
 
+@public
 @payable
 def purchase():
     assert self.unlocked #Contract still open (item still up for sale)?
     assert msg.value == (2*self.value) #Is the deposit of correct value?
     self.buyer = msg.sender
     self.unlocked = false
-    
+
+@public
 def received():
     assert not self.unlocked #Is the item already purchased and pending confirmation of buyer
     assert msg.sender == self.buyer 

--- a/examples/stock/company.v.py
+++ b/examples/stock/company.v.py
@@ -7,6 +7,7 @@ price: public(num (wei / currency))
 holdings: currency_value[address]
 
 # Setup company
+@public
 def __init__(_company: address, _total_shares: currency_value, 
         initial_price: num(wei / currency) ):
     assert _total_shares > 0
@@ -20,11 +21,13 @@ def __init__(_company: address, _total_shares: currency_value,
     # Company holds all the shares at first, but can sell them all
     self.holdings[self.company] = _total_shares
 
+@public
 @constant
 def stock_available() -> currency_value:
     return self.holdings[self.company]
 
 # Give value to company and get stock in return
+@public
 @payable
 def buy_stock():
     # Note: full amount is given to company (no fractional shares),
@@ -39,16 +42,19 @@ def buy_stock():
     self.holdings[msg.sender] += buy_order
 
 # So someone can find out how much they have
+@public
 @constant
 def get_holding(_stockholder: address) -> currency_value:
     return self.holdings[_stockholder]
 
 # The amount the company has on hand in cash
+@public
 @constant
 def cash() -> wei_value:
     return self.balance
 
 # Give stock back to company and get my money back!
+@public
 def sell_stock(sell_order: currency_value):
     assert sell_order > 0 # Otherwise, will fail at send() below
     # Can only sell as much stock as you own
@@ -64,6 +70,7 @@ def sell_stock(sell_order: currency_value):
 
 # Transfer stock from one stockholder to another
 # (Assumes the receiver is given some compensation, but not enforced)
+@public
 def transfer_stock(receiver: address, transfer_order: currency_value):
     assert transfer_order > 0 # AUDIT revealed this!
     # Can only trade as much stock as you own
@@ -74,6 +81,7 @@ def transfer_stock(receiver: address, transfer_order: currency_value):
     self.holdings[receiver] += transfer_order
 
 # Allows the company to pay someone for services rendered
+@public
 def pay_bill(vendor: address, amount: wei_value):
     # Only the company can pay people
     assert msg.sender == self.company
@@ -84,11 +92,13 @@ def pay_bill(vendor: address, amount: wei_value):
     send(vendor, amount)
 
 # The amount a company has raised in the stock offering
+@public
 @constant
 def debt() -> wei_value:
     return (self.total_shares - self.holdings[self.company]) * self.price
 
 # The balance sheet of the company
+@public
 @constant
 def worth() -> wei_value:
     return self.cash() - self.debt()

--- a/examples/tokens/ERC20_solidity_compatible/ERC20.v.py
+++ b/examples/tokens/ERC20_solidity_compatible/ERC20.v.py
@@ -16,6 +16,7 @@ balances: num256[address]
 allowances: (num256[address])[address]
 num_issued: num256
 
+@public
 @payable
 def deposit():
     _value = as_num256(msg.value)
@@ -25,6 +26,7 @@ def deposit():
     # Fire deposit event as transfer from 0x0
     log.Transfer(0x0000000000000000000000000000000000000000, _sender, _value)
 
+@public
 def withdraw(_value : num256) -> bool:
     _sender = msg.sender
     # Make sure sufficient funds are present, op will not underflow supply
@@ -36,14 +38,17 @@ def withdraw(_value : num256) -> bool:
     log.Transfer(_sender, 0x0000000000000000000000000000000000000000, _value)
     return true
 
+@public
 @constant
 def totalSupply() -> num256:
     return self.num_issued
 
+@public
 @constant
 def balanceOf(_owner : address) -> num256:
     return self.balances[_owner]
 
+@public
 def transfer(_to : address, _value : num256) -> bool:
     _sender = msg.sender
     # Make sure sufficient funds are present implicitly through overflow protection
@@ -53,6 +58,7 @@ def transfer(_to : address, _value : num256) -> bool:
     log.Transfer(_sender, _to, _value)
     return true
 
+@public
 def transferFrom(_from : address, _to : address, _value : num256) -> bool:
     _sender = msg.sender
     allowance = self.allowances[_from][_sender]
@@ -64,6 +70,7 @@ def transferFrom(_from : address, _to : address, _value : num256) -> bool:
     log.Transfer(_from, _to, _value)
     return true
 
+@public
 def approve(_spender : address, _value : num256) -> bool:
     _sender = msg.sender
     self.allowances[_sender][_spender] = _value
@@ -71,6 +78,7 @@ def approve(_spender : address, _value : num256) -> bool:
     log.Approval(_sender, _spender, _value)
     return true
 
+@public
 @constant
 def allowance(_owner : address, _spender : address) -> num256:
     return self.allowances[_owner][_spender]

--- a/examples/tokens/vipercoin.v.py
+++ b/examples/tokens/vipercoin.v.py
@@ -16,22 +16,22 @@ decimals: num
 balances: num[address]
 allowed: num[address][address]
 
-
+@public
 def __init__(_name: bytes32, _symbol: bytes32, _decimals: num, _initialSupply: num):
-
+    
     self.name = _name
     self.symbol = _symbol
     self.decimals = _decimals
     self.totalSupply = _initialSupply * 10 ** _decimals
     self.balances[msg.sender] = self.totalSupply
 
-
+@public
 @constant
 def symbol() -> bytes32:
 
     return self.symbol
 
-
+@public
 @constant
 def name() -> bytes32:
 
@@ -39,6 +39,7 @@ def name() -> bytes32:
 
 
 # What is the balance of a particular account?
+@public
 @constant
 def balanceOf(_owner: address) -> num256:
 
@@ -46,6 +47,7 @@ def balanceOf(_owner: address) -> num256:
 
 
 # Return total supply of token.
+@public
 @constant
 def totalSupply() -> num256:
 
@@ -53,6 +55,7 @@ def totalSupply() -> num256:
 
 
 # Send `_value` tokens to `_to` from your account
+@public
 def transfer(_to: address, _amount: num(num256)) -> bool:
 
     if self.balances[msg.sender] >= _amount and \
@@ -68,6 +71,7 @@ def transfer(_to: address, _amount: num(num256)) -> bool:
 
 
 # Transfer allowed tokens from a specific account to another.
+@public
 def transferFrom(_from: address, _to: address, _value: num(num256)) -> bool:
 
     if _value <= self.allowed[_from][msg.sender] and \
@@ -92,6 +96,7 @@ def transferFrom(_from: address, _to: address, _value: num(num256)) -> bool:
 #       same spender. THOUGH The contract itself shouldn't enforce it, to allow
 #       backwards compatilibilty with contracts deployed before.
 #
+@public
 def approve(_spender: address, _amount: num(num256)) -> bool:
 
     self.allowed[msg.sender][_spender] = _amount
@@ -101,6 +106,7 @@ def approve(_spender: address, _amount: num(num256)) -> bool:
 
 
 # Get the allowance an address has to spend anothers' token.
+@public
 def allowance(_owner: address, _spender: address) -> num256:
 
     return as_num256(self.allowed[_owner][_spender])

--- a/examples/voting/ballot.v.py
+++ b/examples/voting/ballot.v.py
@@ -24,17 +24,20 @@ voter_count: public(num)
 chairperson: public(address)
 num_proposals: public(num)
 
+@public
 @constant
 def delegated(addr: address) -> bool:
     # equivalent to self.voters[addr].delegate != 0x0000000000000000000000000000000000000000
     return not not self.voters[addr].delegate
 
+@public
 @constant
 def directly_voted(addr: address) -> bool:
     # not <address> equivalent to <address> == 0x0000000000000000000000000000000000000000
     return self.voters[addr].voted and not self.voters[addr].delegate
 
 # Setup global variables
+@public
 def __init__(_proposalNames: bytes32[2]):
     self.chairperson = msg.sender
     self.voter_count = 0
@@ -47,6 +50,7 @@ def __init__(_proposalNames: bytes32[2]):
 
 # Give `voter` the right to vote on this ballot.
 # May only be called by `chairperson`.
+@public
 def give_right_to_vote(voter: address):
     # Throws if sender is not chairperson
     assert msg.sender == self.chairperson
@@ -58,6 +62,7 @@ def give_right_to_vote(voter: address):
     self.voter_count += 1
 
 # Used by `delegate`. Can be called by anyone.
+@public
 def forward_weight(delegate_with_weight_to_forward: address):
     assert self.delegated(delegate_with_weight_to_forward)
     # Throw if there is nothing to do:
@@ -91,6 +96,7 @@ def forward_weight(delegate_with_weight_to_forward: address):
     # to be called again.
 
 # Delegate your vote to the voter `to`.
+@public
 def delegate(to: address):
     # Throws if sender has already voted
     assert not self.voters[msg.sender].voted
@@ -107,6 +113,7 @@ def delegate(to: address):
 
 # Give your vote (including votes delegated to you)
 # to proposal `proposals[proposal].name`.
+@public
 def vote(proposal: num):
     # can't vote twice
     assert not self.voters[msg.sender].voted
@@ -121,6 +128,7 @@ def vote(proposal: num):
 
 # Computes the winning proposal taking all
 # previous votes into account.
+@public
 @constant
 def winning_proposal() -> num:
     winning_vote_count = 0
@@ -133,6 +141,7 @@ def winning_proposal() -> num:
 # Calls winning_proposal() function to get the index
 # of the winner contained in the proposals array and then
 # returns the name of the winner
+@public
 @constant
 def winner_name() -> bytes32:
     return self.proposals[self.winning_proposal()].name

--- a/examples/wallet/wallet.v.py
+++ b/examples/wallet/wallet.v.py
@@ -8,6 +8,7 @@ threshold: num
 # The number of transactions that have been approved
 seq: num
 
+@public
 def __init__(_owners: address[5], _threshold: num):
     for i in range(5):
         if _owners[i]:
@@ -15,6 +16,7 @@ def __init__(_owners: address[5], _threshold: num):
     self.threshold = _threshold
 
 # `@payable` allows functions to receive ether
+@public
 @payable
 def approve(_seq: num, to: address, value: wei_value, data: bytes <= 4096, sigdata: num256[3][5]) -> bytes <= 4096:
     # Throws if the value sent to the contract is less than the sum of the value to be sent

--- a/tests/parser/exceptions/test_constancy_exception.py
+++ b/tests/parser/exceptions/test_constancy_exception.py
@@ -8,16 +8,19 @@ from viper.exceptions import ConstancyViolationException
 fail_list = [
     """
 x: num
+@public
 @constant
 def foo() -> num:
     self.x = 5
     """,
     """
+@public
 @constant
 def foo() -> num:
     send(0x1234567890123456789012345678901234567890, 5)
     """,
     """
+@public
 @constant
 def foo() -> num:
     selfdestruct(0x1234567890123456789012345678901234567890)
@@ -25,24 +28,28 @@ def foo() -> num:
     """
 x: timedelta
 y: num
+@public
 @constant
 def foo() -> num(sec):
     self.y = 9
     return 5
     """,
     """
+@public
 @constant
 def foo() -> num:
     x = raw_call(0x1234567890123456789012345678901234567890, "cow", outsize=4, gas=595757, value=9)
     return 5
     """,
     """
+@public
 @constant
 def foo() -> num:
     x = create_with_code_of(0x1234567890123456789012345678901234567890, value=9)
     return 5
     """,
     """
+@public
 def foo(x: num):
     x = 5
     """

--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -7,71 +7,88 @@ from viper.exceptions import InvalidLiteralException
 
 fail_list = [
     """
+@public
 def foo():
     x = 0x12345678901234567890123456789012345678901
     """,
     """
+@public
 def foo():
     x = 0x01234567890123456789012345678901234567890
     """,
     """
+@public
 def foo():
     x = 0x123456789012345678901234567890123456789
     """,
     """
+@public
 def foo():
     x = -170141183460469231731687303715884105729 # -2**127 - 1
     """,
     """
+@public
 def foo():
     x = -170141183460469231731687303715884105728.
     """,
     """
 b: decimal
+@public
 def foo():
     self.b = 7.5178246872145875217495129745982164981654986129846
     """,
     """
+@public
 def foo():
     x = "these bytes are nо gооd because the o's are from the Russian alphabet"
     """,
     """
+@public
 def foo():
     x = "这个傻老外不懂中文"
     """,
     """
+@public
 def foo():
     x = raw_call(0x123456789012345678901234567890123456789, "cow", outsize=4)
     """,
     """
+@public
 def foo():
     x = create_with_code_of(0x123456789012345678901234567890123456789)
     """,
     """
+@public
 def foo():
     x = as_wei_value(5.1824, ada)
     """,
     """
+@public
 def foo():
     x = as_wei_value(0x05, ada)
     """,
     """
+@public
 def foo():
     x = as_wei_value(5, vader)
     """,
     """
+@public
 def foo():
     send(0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae, 5)
     """,
     """
+@public
 def foo():
     x = as_num256(821649876217461872458712528745872158745214187264875632587324658732648753245328764872135671285218762145)
     """,
     """
+@public
 def foo():
     x = as_num256(-1)
     """,
     """
+@public
 def foo():
     x = as_num256(3.1415)
     """

--- a/tests/parser/exceptions/test_invalid_payable.py
+++ b/tests/parser/exceptions/test_invalid_payable.py
@@ -7,6 +7,7 @@ from viper.exceptions import NonPayableViolationException
 
 fail_list = [
     """
+@public
 def foo():
     x = msg.value
 """
@@ -22,11 +23,13 @@ def test_variable_decleration_exception(bad_code):
 valid_list = [
     """
 x: num
+@public
 @payable
 def foo() -> num:
     self.x = 5
     """,
     """
+@public
 @payable
 def foo():
     x = msg.value

--- a/tests/parser/exceptions/test_invalid_type_exception.py
+++ b/tests/parser/exceptions/test_invalid_type_exception.py
@@ -52,10 +52,12 @@ b: num[num: address]
     """,
     """
 x: num[address[bool]]
+@public
 def foo() -> num(wei / sec):
     pass
     """,
     """
+@public
 def foo() -> {cow: num, dog: num}:
     return {cow: 5, dog: 7}
     """

--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -10,6 +10,7 @@ fail_list = [
 x[5] = 4
     """,
     """
+@public
 def foo(): pass
 
 x: num
@@ -22,26 +23,31 @@ send(0x1234567890123456789012345678901234567890, 5)
     """,
     """
 x: num[5]
+@public
 def foo():
     self.x[2:4] = 3
     """,
     """
 x: num[5]
+@public
 def foo():
     z = self.x[2:4]
     """,
     """
+@public
 def foo():
     x: num[5]
     z = x[2:4]
     """,
     """
+@public
 def foo():
     x = 5
     for i in range(x):
         pass
     """,
     """
+@public
 def foo():
     x = 5
     y = 7
@@ -50,48 +56,58 @@ def foo():
     """,
     """
 x: num
+@public
 @const
 def foo() -> num:
     pass
     """,
     """
 x: num
+@public
 @monkeydoodledoo
 def foo() -> num:
     pass
     """,
     """
 x: num
+@public
 @constant(123)
 def foo() -> num:
     pass
     """,
     """
 foo: num[3]
+@public
 def foo():
     self.foo = []
     """,
     """
+@public
 def foo():
     x = sha3("moose", 3)
     """,
     """
+@public
 def foo():
     x = raw_call(0x1234567890123456789012345678901234567890, "cow")
     """,
     """
+@public
 def foo():
     x = raw_call(0x1234567890123456789012345678901234567890, outsize=4)
     """,
     """
+@public
 def foo():
     x = create_with_code_of(0x1234567890123456789012345678901234567890, "cow")
     """,
     """
+@public
 def foo():
     x = raw_call(0x1234567890123456789012345678901234567890, "cow", gas=111111, outsize=4, moose=9)
     """,
     """
+@public
 def foo():
     x = create_with_code_of(0x1234567890123456789012345678901234567890, outsize=4)
     """,
@@ -99,36 +115,44 @@ def foo():
 x: public()
     """,
     """
+@public
 def foo():
     raw_log([], "cow", "dog")
     """,
     """
+@public
 def foo():
     raw_log("cow", "dog")
     """,
     """
+@public
 def foo():
     throe
     """,
     """
+@public
 def foo() -> num(wei):
     x = 0x1234567890123456789012345678901234567890
     return x.balance()
     """,
     """
+@public
 def foo() -> num:
     x = 0x1234567890123456789012345678901234567890
     return x.codesize()
     """,
     """
+@public
 def foo():
     x = ~self
     """,
     """
+@public
 def foo():
     x = concat("")
     """,
     """
+@public
 def foo():
     x = y = 3
     """,

--- a/tests/parser/exceptions/test_variable_declaration_exception.py
+++ b/tests/parser/exceptions/test_variable_declaration_exception.py
@@ -13,68 +13,84 @@ x: num
     """
 x: num
 
+@public
 def foo(x: num): pass
     """,
     """
+@public
 def foo(x: num, x: num): pass
     """,
     """
+@public
 def foo(num: num):
     pass
     """,
     """
+@public
 def foo():
     x = 5
     x: num
     """,
     """
+@public
 def foo():
     x: num
     x: num
     """,
     """
+@public
 def foo():
     x: num
+@public
 def foo():
     y: num
     """,
     """
+@public
 def foo():
     num = 5
     """,
     """
+@public
 def foo():
     bork = zork
     """,
 
     """
 x: num
+@public
 def foo():
     x = 5
     """,
     """
 b: num
+@public
 def foo():
     b = 7
     """,
     """
 x: wei_value
 
+@public
 def foo():
     send(0x1234567890123456789012345678901234567890, x)
     """,
     """
+@public
 def foo():
     true = 3
     """,
     """
+@public
 def foo():
     self.goo()
 
+@public
 def goo():
     self.foo()
     """,
     """
+@public
 def foo():
     BALANCE = 45
     """,

--- a/tests/parser/features/decorators/test_internal.py
+++ b/tests/parser/features/decorators/test_internal.py
@@ -9,6 +9,7 @@ def test_internal_test():
 def a() -> num:
     return 5
 
+@public
 def returnten() -> num:
     return self.a() * 2
     """

--- a/tests/parser/features/decorators/test_public.py
+++ b/tests/parser/features/decorators/test_public.py
@@ -1,0 +1,28 @@
+import pytest
+from viper.exceptions import StructureException
+
+from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
+    get_contract_with_gas_estimation, get_contract
+
+
+def test_invalid_if_both_public_and_internal(assert_compile_failed):
+    code = """
+@public
+@internal
+def foo():
+    x = 1
+"""
+
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
+
+
+def test_invalid_if_visibility_isnt_declared(assert_compile_failed):
+    code = """
+def foo():
+    x = 1
+"""
+
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
+
+
+

--- a/tests/parser/features/iteration/test_break.py
+++ b/tests/parser/features/iteration/test_break.py
@@ -5,6 +5,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_break_test():
     break_test = """
+@public
 def log(n: num) -> num:
     c = n * 1.0
     output = 0
@@ -26,6 +27,7 @@ def log(n: num) -> num:
 
 def test_break_test_2():
     break_test_2 = """
+@public
 def log(n: num) -> num:
     c = n * 1.0
     output = 0
@@ -53,6 +55,7 @@ def log(n: num) -> num:
 
 def test_break_test_3():
     break_test_3 = """
+@public
 def log(n: num) -> num:
     c = decimal(n)
     output = 0

--- a/tests/parser/features/iteration/test_for_in_list.py
+++ b/tests/parser/features/iteration/test_for_in_list.py
@@ -6,6 +6,7 @@ from viper.exceptions import StructureException
 
 def test_basic_for_in_list():
     code = """
+@public
 def data() -> num:
     s = [1, 2, 3, 4, 5, 6]
     for i in s:
@@ -21,6 +22,7 @@ def data() -> num:
 
 def test_basic_for_list_liter():
     code = """
+@public
 def data() -> num:
     for i in [3, 5, 7, 9]:
         if i > 5:
@@ -37,9 +39,11 @@ def test_basic_for_list_storage():
     code = """
 x: num[4]
 
+@public
 def set():
     self.x = [3, 5, 7, 9]
 
+@public
 def data() -> num:
     for i in self.x:
         if i > 5:
@@ -56,6 +60,7 @@ def data() -> num:
 
 def test_basic_for_list_address():
     code = """
+@public
 def data() -> address:
     addresses = [
         0x7d577a597B2742b498Cb5Cf0C26cDCD726d39E6e,
@@ -79,12 +84,15 @@ def test_basic_for_list_storage_address():
     code = """
 addresses: address[3]
 
+@public
 def set(i: num, val: address):
     self.addresses[i] = val
 
+@public
 def ret(i: num) -> address:
     return self.addresses[i]
 
+@public
 def iterate_return_second() -> address:
     count = 0
     for i in self.addresses:
@@ -106,12 +114,15 @@ def test_basic_for_list_storage_decimal():
     code = """
 readings: decimal[3]
 
+@public
 def set(i: num, val: decimal):
     self.readings[i] = val
 
+@public
 def ret(i: num) -> decimal:
     return self.readings[i]
 
+@public
 def i_return(break_count: num) -> decimal:
     count = 0
     for i in self.readings:
@@ -133,6 +144,7 @@ def i_return(break_count: num) -> decimal:
 
 def test_altering_list_within_for_loop(assert_compile_failed):
     code = """
+@public
 def data() -> num:
     s = [1, 2, 3, 4, 5, 6]
     count = 0
@@ -151,9 +163,11 @@ def test_altering_list_within_for_loop_storage(assert_compile_failed):
     code = """
 s: num[6]
 
+@public
 def set():
     self.s = [1, 2, 3, 4, 5, 6]
 
+@public
 def data() -> num:
     count = 0
     for i in self.s:

--- a/tests/parser/features/iteration/test_range_in.py
+++ b/tests/parser/features/iteration/test_range_in.py
@@ -6,6 +6,7 @@ from viper.exceptions import TypeMismatchException
 
 def test_basic_in_list():
     code = """
+@public
 def testin(x: num) -> bool:
     y = 1
     s = [1, 2, 3, 4]
@@ -29,6 +30,7 @@ def test_in_storage_list():
     code = """
 allowed: num[10]
 
+@public
 def in_test(x: num) -> bool:
     self.allowed = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     if x in self.allowed:
@@ -47,6 +49,7 @@ def in_test(x: num) -> bool:
 
 def test_cmp_in_list():
     code = """
+@public
 def in_test(x: num) -> bool:
     if x in [9, 7, 6, 5]:
         return True
@@ -64,6 +67,7 @@ def in_test(x: num) -> bool:
 
 def test_mixed_in_list(assert_compile_failed):
     code = """
+@public
 def testin() -> bool:
     s = [1, 2, 3, 4]
     if "test" in s:

--- a/tests/parser/features/iteration/test_repeater.py
+++ b/tests/parser/features/iteration/test_repeater.py
@@ -5,6 +5,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_basic_repeater():
     basic_repeater = """
+@public
 def repeat(z: num) -> num:
     x = 0
     for i in range(6):
@@ -18,7 +19,7 @@ def repeat(z: num) -> num:
 
 def test_digit_reverser():
     digit_reverser = """
-
+@public
 def reverse_digits(x: num) -> num:
     dig: num[6]
     z = x
@@ -39,6 +40,7 @@ def reverse_digits(x: num) -> num:
 
 def test_more_complex_repeater():
     more_complex_repeater = """
+@public
 def repeat() -> num:
     out = 0
     for i in range(6):
@@ -54,6 +56,7 @@ def repeat() -> num:
 
 def test_offset_repeater():
     offset_repeater = """
+@public
 def sum() -> num:
     out = 0
     for i in range(80, 121):
@@ -69,6 +72,7 @@ def sum() -> num:
 
 def test_offset_repeater_2():
     offset_repeater_2 = """
+@public
 def sum(frm: num, to: num) -> num:
     out = 0
     for i in range(frm, frm + 101):

--- a/tests/parser/features/test_assignment.py
+++ b/tests/parser/features/test_assignment.py
@@ -5,26 +5,31 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_augassign_test():
     augassign_test = """
+@public
 def augadd(x: num, y: num) -> num:
     z = x
     z += y
     return z
 
+@public
 def augmul(x: num, y: num) -> num:
     z = x
     z *= y
     return z
 
+@public
 def augsub(x: num, y: num) -> num:
     z = x
     z -= y
     return z
 
+@public
 def augdiv(x: num, y: num) -> num:
     z = x
     z /= y
     return z
 
+@public
 def augmod(x: num, y: num) -> num:
     z = x
     z %= y

--- a/tests/parser/features/test_clampers.py
+++ b/tests/parser/features/test_clampers.py
@@ -5,6 +5,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_clamper_test_code():
     clamper_test_code = """
+@public
 def foo(s: bytes <= 3) -> bytes <= 3:
     return s
     """

--- a/tests/parser/features/test_comments.py
+++ b/tests/parser/features/test_comments.py
@@ -5,7 +5,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_comment_test():
     comment_test = """
-
+@public
 def foo() -> num:
     # Returns 3
     return 3

--- a/tests/parser/features/test_conditionals.py
+++ b/tests/parser/features/test_conditionals.py
@@ -5,6 +5,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_conditional_return_code():
     conditional_return_code = """
+@public
 def foo(i: bool) -> num:
     if i:
         return 5

--- a/tests/parser/features/test_constructor.py
+++ b/tests/parser/features/test_constructor.py
@@ -6,9 +6,12 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 def test_init_argument_test():
     init_argument_test = """
 moose: num
+
+@public
 def __init__(_moose: num):
     self.moose = _moose
 
+@public
 def returnMoose() -> num:
     return self.moose
     """
@@ -22,9 +25,11 @@ def test_constructor_advanced_code():
     constructor_advanced_code = """
 twox: num
 
+@public
 def __init__(x: num):
     self.twox = x * 2
 
+@public
 def get_twox() -> num:
     return self.twox
     """
@@ -36,9 +41,11 @@ def test_constructor_advanced_code2():
     constructor_advanced_code2 = """
 comb: num
 
+@public
 def __init__(x: num[2], y: bytes <= 3, z: num):
     self.comb = x[0] * 1000 + x[1] * 100 + len(y) * 10 + z
 
+@public
 def get_comb() -> num:
     return self.comb
     """
@@ -49,6 +56,7 @@ def get_comb() -> num:
 
 def test_large_input_code():
     large_input_code = """
+@public
 def foo(x: num) -> num:
     return 3
     """
@@ -66,9 +74,11 @@ def foo(x: num) -> num:
 
 def test_large_input_code_2():
     large_input_code_2 = """
+@public
 def __init__(x: num):
     y = x
 
+@public
 def foo() -> num:
     return 5
     """

--- a/tests/parser/features/test_external_contract_calls.py
+++ b/tests/parser/features/test_external_contract_calls.py
@@ -5,6 +5,7 @@ from viper.exceptions import StructureException, VariableDeclarationException, I
 
 def test_external_contract_calls():
     contract_1 = """
+@public
 def foo(arg1: num) -> num:
     return arg1
     """
@@ -15,6 +16,7 @@ def foo(arg1: num) -> num:
 class Foo():
         def foo(arg1: num) -> num: pass
 
+@public
 def bar(arg1: address, arg2: num) -> num:
     return Foo(arg1).foo(arg2)
     """
@@ -28,12 +30,15 @@ def test_complicated_external_contract_calls():
     contract_1 = """
 lucky: public(num)
 
+@public
 def __init__(_lucky: num):
     self.lucky = _lucky
 
+@public
 def foo() -> num:
     return self.lucky
 
+@public
 def array() -> bytes <= 3:
     return 'dog'
     """
@@ -46,6 +51,7 @@ class Foo():
     def foo() -> num: pass
     def array() -> bytes <= 3: pass
 
+@public
 def bar(arg1: address) -> num:
     return Foo(arg1).foo()
     """
@@ -57,6 +63,7 @@ def bar(arg1: address) -> num:
 
 def test_external_contract_calls_with_bytes():
     contract_1 = """
+@public
 def array() -> bytes <= 3:
     return 'dog'
     """
@@ -67,6 +74,7 @@ def array() -> bytes <= 3:
 class Foo():
     def array() -> bytes <= 3: pass
 
+@public
 def get_array(arg1: address) -> bytes <= 3:
     return Foo(arg1).array()
 """
@@ -79,6 +87,7 @@ def test_external_contract_call_state_change():
     contract_1 = """
 lucky: public(num)
 
+@public
 def set_lucky(_lucky: num):
     self.lucky = _lucky
     """
@@ -90,6 +99,7 @@ def set_lucky(_lucky: num):
 class Foo():
     def set_lucky(_lucky: num): pass
 
+@public
 def set_lucky(arg1: address, arg2: num):
     Foo(arg1).set_lucky(arg2)
     """
@@ -136,6 +146,7 @@ def test_external_contract_can_be_changed_based_on_address():
     contract_1 = """
 lucky: public(num)
 
+@public
 def set_lucky(_lucky: num):
     self.lucky = _lucky
     """
@@ -146,6 +157,7 @@ def set_lucky(_lucky: num):
     contract_2 =  """
 lucky: public(num)
 
+@public
 def set_lucky(_lucky: num):
     self.lucky = _lucky
     """
@@ -157,6 +169,7 @@ def set_lucky(_lucky: num):
 class Foo():
     def set_lucky(_lucky: num): pass
 
+@public
 def set_lucky(arg1: address, arg2: num):
     Foo(arg1).set_lucky(arg2)
     """
@@ -173,6 +186,7 @@ def test_external_contract_calls_with_public_globals():
     contract_1 = """
 lucky: public(num)
 
+@public
 def __init__(_lucky: num):
     self.lucky = _lucky
     """
@@ -184,6 +198,7 @@ def __init__(_lucky: num):
 class Foo():
     def get_lucky() -> num: pass
 
+@public
 def bar(arg1: address) -> num:
     return Foo(arg1).get_lucky()
     """
@@ -197,6 +212,7 @@ def test_external_contract_calls_with_multiple_contracts():
     contract_1 = """
 lucky: public(num)
 
+@public
 def __init__(_lucky: num):
     self.lucky = _lucky
     """
@@ -210,6 +226,7 @@ class Foo():
 
 magic_number: public(num)
 
+@public
 def __init__(arg1: address):
     self.magic_number = Foo(arg1).get_lucky()
     """
@@ -221,6 +238,7 @@ class Bar():
 
 best_number: public(num)
 
+@public
 def __init__(arg1: address):
     self.best_number = Bar(arg1).get_magic_number()
     """
@@ -232,6 +250,7 @@ def __init__(arg1: address):
 
 def test_invalid_external_contract_call_to_the_same_contract(assert_tx_failed):
     contract_1 = """
+@public
 def bar() -> num:
     return 1
     """
@@ -240,12 +259,15 @@ def bar() -> num:
 class Bar():
     def bar() -> num: pass
 
+@public
 def bar() -> num:
     return 1
 
+@public
 def _stmt(x: address):
     Bar(x).bar()
 
+@public
 def _expr(x: address) -> num:
     return Bar(x).bar()
     """
@@ -262,6 +284,7 @@ def _expr(x: address) -> num:
 
 def test_invalid_nonexistent_contract_call(assert_tx_failed):
     contract_1 = """
+@public
 def bar() -> num:
     return 1
     """
@@ -270,6 +293,7 @@ def bar() -> num:
 class Bar():
     def bar() -> num: pass
 
+@public
 def foo(x: address) -> num:
     return Bar(x).bar()
     """
@@ -290,6 +314,7 @@ class Bar():
 
 best_number: public(num)
 
+@public
 def __init__():
     pass
 """
@@ -299,6 +324,7 @@ def __init__():
 
 def test_invalid_contract_reference_call(assert_tx_failed):
     contract = """
+@public
 def bar(arg1: address, arg2: num) -> num:
     return Foo(arg1).foo(arg2)
 """
@@ -311,6 +337,7 @@ def test_invalid_contract_reference_return_type(assert_tx_failed):
 class Foo():
     def foo(arg2: num) -> invalid: pass
 
+@public
 def bar(arg1: address, arg2: num) -> num:
     return Foo(arg1).foo(arg2)
 """
@@ -344,7 +371,7 @@ class Foo():
 
 def test_external_contracts_must_be_declared_first_3(assert_tx_failed):
     contract = """
-
+@public
 def foo() -> num:
     return 1
 

--- a/tests/parser/features/test_external_contract_calls.py
+++ b/tests/parser/features/test_external_contract_calls.py
@@ -115,6 +115,7 @@ def test_constant_external_contract_call_cannot_change_state(assert_tx_failed):
     contract_1 = """
 lucky: public(num)
 
+@public
 def set_lucky(_lucky: num) -> num:
     self.lucky = _lucky
     return _lucky
@@ -127,10 +128,12 @@ def set_lucky(_lucky: num) -> num:
 class Foo():
     def set_lucky(_lucky: num) -> num: pass
 
+@public
 @constant
 def set_lucky_expr(arg1: address, arg2: num):
     Foo(arg1).set_lucky(arg2)
 
+@public
 @constant
 def set_lucky_stmt(arg1: address, arg2: num) -> num:
     return Foo(arg1).set_lucky(arg2)

--- a/tests/parser/features/test_gas.py
+++ b/tests/parser/features/test_gas.py
@@ -8,7 +8,7 @@ from viper.parser import parser_utils
 
 def test_gas_call():
     gas_call = """
-
+@public
 def foo() -> num:
     return msg.gas
     """
@@ -24,7 +24,7 @@ def test_gas_estimate_repr():
     code = """
 x: num
 
-
+@public
 def __init__():
     self.x = 1
     """

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -5,9 +5,11 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_selfcall_code():
     selfcall_code = """
+@public
 def foo() -> num:
     return 3
 
+@public
 def bar() -> num:
     return self.foo()
     """
@@ -20,15 +22,19 @@ def bar() -> num:
 
 def test_selfcall_code_2():
     selfcall_code_2 = """
+@public
 def double(x: num) -> num:
     return x * 2
 
+@public
 def returnten() -> num:
     return self.double(5)
 
+@public
 def _hashy(x: bytes32) -> bytes32:
     return sha3(x)
 
+@public
 def return_hash_of_rzpadded_cow() -> bytes32:
     return self._hashy(0x636f770000000000000000000000000000000000000000000000000000000000)
     """
@@ -42,15 +48,19 @@ def return_hash_of_rzpadded_cow() -> bytes32:
 
 def test_selfcall_code_3():
     selfcall_code_3 = """
+@public
 def _hashy2(x: bytes <= 100) -> bytes32:
     return sha3(x)
 
+@public
 def return_hash_of_cow_x_30() -> bytes32:
     return self._hashy2("cowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcow")
 
+@public
 def _len(x: bytes <= 100) -> num:
     return len(x)
 
+@public
 def returnten() -> num:
     return self._len("badminton!")
     """
@@ -64,27 +74,35 @@ def returnten() -> num:
 
 def test_selfcall_code_4():
     selfcall_code_4 = """
+@public
 def summy(x: num, y: num) -> num:
     return x + y
 
+@public
 def catty(x: bytes <= 5, y: bytes <= 5) -> bytes <= 10:
     return concat(x, y)
 
+@public
 def slicey1(x: bytes <= 10, y: num) -> bytes <= 10:
     return slice(x, start=0, len=y)
 
+@public
 def slicey2(y: num, x: bytes <= 10) -> bytes <= 10:
     return slice(x, start=0, len=y)
 
+@public
 def returnten() -> num:
     return self.summy(3, 7)
 
+@public
 def return_mongoose() -> bytes <= 10:
     return self.catty("mon", "goose")
 
+@public
 def return_goose() -> bytes <= 10:
     return self.slicey1("goosedog", 5)
 
+@public
 def return_goose2() -> bytes <= 10:
     return self.slicey2(5, "goosedog")
     """
@@ -102,9 +120,11 @@ def test_selfcall_code_5():
     selfcall_code_5 = """
 counter: num
 
+@public
 def increment():
     self.counter += 1
 
+@public
 def returnten() -> num:
     for i in range(10):
         self.increment()
@@ -120,15 +140,19 @@ def test_selfcall_code_6():
     selfcall_code_6 = """
 excls: bytes <= 32
 
+@public
 def set_excls(arg: bytes <= 32):
     self.excls = arg
 
+@public
 def underscore() -> bytes <= 1:
     return "_"
 
+@public
 def hardtest(x: bytes <= 100, y: num, z: num, a: bytes <= 100, b: num, c: num) -> bytes <= 201:
     return concat(slice(x, start=y, len=z), self.underscore(), slice(a, start=b, len=c))
 
+@public
 def return_mongoose_revolution_32_excls() -> bytes <= 201:
     self.set_excls("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
     return self.hardtest("megamongoose123", 4, 8, concat("russian revolution", self.excls), 8, 42)

--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -8,6 +8,7 @@ def test_empy_event_logging():
     loggy_code = """
 MyLog: __log__({})
 
+@public
 def foo():
     log.MyLog()
     """
@@ -30,6 +31,7 @@ def test_event_logging_with_topics():
     loggy_code = """
 MyLog: __log__({arg1: indexed(bytes <= 3)})
 
+@public
 def foo():
     log.MyLog('bar')
     """
@@ -52,6 +54,7 @@ def test_event_logging_with_multiple_topics():
     loggy_code = """
 MyLog: __log__({arg1: indexed(bytes <= 3), arg2: indexed(bytes <= 4), arg3: indexed(address)})
 
+@public
 def foo():
     log.MyLog('bar', 'home', self)
     """
@@ -74,10 +77,12 @@ def test_logging_the_same_event_multiple_times_with_topics():
     loggy_code = """
 MyLog: __log__({arg1: indexed(num), arg2: indexed(address)})
 
+@public
 def foo():
     log.MyLog(1, self)
     log.MyLog(1, self)
 
+@public
 def bar():
     log.MyLog(1, self)
     log.MyLog(1, self)
@@ -102,6 +107,7 @@ def test_event_logging_cannot_have_more_than_three_topics(assert_tx_failed):
     loggy_code = """
 MyLog: __log__({arg1: indexed(bytes <= 3), arg2: indexed(bytes <= 4), arg3: indexed(address), arg4: indexed(num)})
 
+@public
 def foo():
     log.MyLog('bar', 'home', self)
     """
@@ -113,6 +119,7 @@ def test_event_logging_with_data():
     loggy_code = """
 MyLog: __log__({arg1: num})
 
+@public
 def foo():
     log.MyLog(123)
     """
@@ -135,6 +142,7 @@ def test_event_loggging_with_fixed_array_data():
     loggy_code = """
 MyLog: __log__({arg1: num[2], arg2: timestamp[3], arg3: num[2][2]})
 
+@public
 def foo():
     log.MyLog([1,2], [block.timestamp, block.timestamp+1, block.timestamp+2], [[1,2],[1,2]])
     log.MyLog([1,2], [block.timestamp, block.timestamp+1, block.timestamp+2], [[1,2],[1,2]])
@@ -159,6 +167,7 @@ def test_logging_with_input_bytes(bytes_helper):
     loggy_code = """
 MyLog: __log__({arg1: indexed(bytes <= 4), arg2: indexed(bytes <= 29), arg3: bytes<=31})
 
+@public
 def foo(arg1: bytes <= 29, arg2: bytes <= 31):
     log.MyLog('bar', arg1, arg2)
 """
@@ -180,11 +189,9 @@ def test_event_logging_with_data_with_different_types():
     loggy_code = """
 MyLog: __log__({arg1: num, arg2: bytes <= 4, arg3: bytes <= 3, arg4: address, arg5: address, arg6: timestamp})
 
+@public
 def foo():
     log.MyLog(123, 'home', 'bar', 0xc305c901078781C232A2a521C2aF7980f8385ee9, self, block.timestamp)
-# MyLog: __log__({arg1: bytes <= 3, arg2: bytes <= 5})
-# def foo():
-#     log.MyLog('bar', 'bears')
     """
 
     c = get_contract_with_gas_estimation(loggy_code)
@@ -205,6 +212,7 @@ def test_event_logging_with_topics_and_data():
     loggy_code = """
 MyLog: __log__({arg1: indexed(num), arg2: bytes <= 3})
 
+@public
 def foo():
     log.MyLog(1, 'bar')
     """
@@ -228,6 +236,7 @@ def test_event_logging_with_multiple_logs_topics_and_data():
 MyLog: __log__({arg1: indexed(num), arg2: bytes <= 3})
 YourLog: __log__({arg1: indexed(address), arg2: bytes <= 5})
 
+@public
 def foo():
     log.MyLog(1, 'bar')
     log.YourLog(self, 'house')
@@ -256,6 +265,8 @@ def foo():
 def test_fails_when_input_is_the_wrong_type(assert_tx_failed):
     loggy_code = """
 MyLog: __log__({arg1: indexed(num)})
+
+@public
 def foo_():
     log.MyLog('yo')
 """
@@ -266,6 +277,8 @@ def foo_():
 def test_fails_when_topic_is_the_wrong_size(assert_tx_failed):
     loggy_code = """
 MyLog: __log__({arg1: indexed(bytes <= 3)})
+
+@public
 def foo():
     log.MyLog('bars')
 """
@@ -276,6 +289,8 @@ def foo():
 def test_fails_when_input_topic_is_the_wrong_size(assert_tx_failed):
     loggy_code = """
 MyLog: __log__({arg1: indexed(bytes <= 3)})
+
+@public
 def foo(arg1: bytes <= 4):
     log.MyLog(arg1)
 """
@@ -286,6 +301,8 @@ def foo(arg1: bytes <= 4):
 def test_fails_when_data_is_the_wrong_size(assert_tx_failed):
     loggy_code = """
 MyLog: __log__({arg1: bytes <= 3})
+
+@public
 def foo():
     log.MyLog('bars')
 """
@@ -296,6 +313,8 @@ def foo():
 def test_fails_when_input_data_is_the_wrong_size(assert_tx_failed):
     loggy_code = """
 MyLog: __log__({arg1: bytes <= 3})
+
+@public
 def foo(arg1: bytes <= 4):
     log.MyLog(arg1)
 """
@@ -306,6 +325,8 @@ def foo(arg1: bytes <= 4):
 def test_fails_when_log_data_is_over_32_bytes(assert_tx_failed):
     loggy_code = """
 MyLog: __log__({arg1: bytes <= 100})
+
+@public
 def foo():
     pass
     """
@@ -316,6 +337,7 @@ def foo():
 def test_logging_fails_with_over_three_topics(assert_tx_failed):
     loggy_code = """
 MyLog: __log__({arg1: indexed(num), arg2: indexed(num), arg3: indexed(num), arg4: indexed(num)})
+@public
 def __init__():
     log.MyLog(1, 2, 3, 4)
     """
@@ -328,6 +350,7 @@ def test_logging_fails_with_duplicate_log_names(assert_tx_failed):
 MyLog: __log__({})
 MyLog: __log__({})
 
+@public
 def foo():
     log.MyLog()
     """
@@ -337,6 +360,8 @@ def foo():
 
 def test_logging_fails_with_when_log_is_undeclared(assert_tx_failed):
     loggy_code = """
+
+@public
 def foo():
     log.MyLog()
     """
@@ -348,6 +373,7 @@ def test_logging_fails_with_topic_type_mismatch(assert_tx_failed):
     loggy_code = """
 MyLog: __log__({arg1: indexed(num)})
 
+@public
 def foo():
     log.MyLog(self)
     """
@@ -359,6 +385,7 @@ def test_logging_fails_with_data_type_mismatch(assert_tx_failed):
     loggy_code = """
 MyLog: __log__({arg1: bytes <= 3})
 
+@public
 def foo():
     log.MyLog(self)
     """
@@ -377,6 +404,8 @@ MyLog: __log__({arg1: bytes <= 3})
 
 def test_logging_fails_after_a_function_declaration(assert_tx_failed):
     loggy_code = """
+
+@public
 def foo():
     pass
 
@@ -390,16 +419,20 @@ def test_loggy_code():
     loggy_code = """
 s: bytes <= 100
 
+@public
 def foo():
     raw_log([], "moo")
 
+@public
 def goo():
     raw_log([0x1234567812345678123456781234567812345678123456781234567812345678], "moo2")
 
+@public
 def hoo():
     self.s = "moo3"
     raw_log([], self.s)
 
+@public
 def ioo(inp: bytes <= 100):
     raw_log([], inp)
     """

--- a/tests/parser/features/test_packing.py
+++ b/tests/parser/features/test_packing.py
@@ -10,6 +10,7 @@ y: num[5]
 z: {foo: num[3], bar: {a: num, b: num}[2]}
 a: num
 
+@public
 def foo() -> num:
     self.x = 1
     self.y[0] = 2
@@ -24,6 +25,7 @@ def foo() -> num:
     return self.x + self.y[0] + self.y[4] + self.z.foo[0] + self.z.foo[2] + \
         self.z.bar[0].a + self.z.bar[0].b + self.z.bar[1].a + self.z.bar[1].b + self.a
 
+@public
 def fop() -> num:
     _x: num
     _y: num[5]

--- a/tests/parser/functions/test_bitwise.py
+++ b/tests/parser/functions/test_bitwise.py
@@ -5,18 +5,23 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_test_bitwise():
     test_bitwise = """
+@public
 def _bitwise_and(x: num256, y: num256) -> num256:
     return bitwise_and(x, y)
 
+@public
 def _bitwise_or(x: num256, y: num256) -> num256:
     return bitwise_or(x, y)
 
+@public
 def _bitwise_xor(x: num256, y: num256) -> num256:
     return bitwise_xor(x, y)
 
+@public
 def _bitwise_not(x: num256) -> num256:
     return bitwise_not(x)
 
+@public
 def _shift(x: num256, y: num) -> num256:
     return shift(x, y)
     """

--- a/tests/parser/functions/test_block_number.py
+++ b/tests/parser/functions/test_block_number.py
@@ -5,6 +5,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_block_number():
     block_number_code = """
+@public
 def block_number() -> num:
     return block.number
 """

--- a/tests/parser/functions/test_concat.py
+++ b/tests/parser/functions/test_concat.py
@@ -5,9 +5,11 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_concat():
     test_concat = """
+@public
 def foo2(input1: bytes <= 50, input2: bytes <= 50) -> bytes <= 1000:
     return concat(input1, input2)
 
+@public
 def foo3(input1: bytes <= 50, input2: bytes <= 50, input3: bytes <= 50) -> bytes <= 1000:
     return concat(input1, input2, input3)
     """
@@ -26,6 +28,7 @@ def foo3(input1: bytes <= 50, input2: bytes <= 50, input3: bytes <= 50) -> bytes
 
 def test_concat2():
     test_concat2 = """
+@public
 def foo(inp: bytes <= 50) -> bytes <= 1000:
     x = inp
     return concat(x, inp, x, inp, x, inp, x, inp, x, inp)
@@ -40,6 +43,7 @@ def test_crazy_concat_code():
     crazy_concat_code = """
 y: bytes <= 10
 
+@public
 def krazykonkat(z: bytes <= 10) -> bytes <= 25:
     x = "cow"
     self.y = "horse"
@@ -55,9 +59,11 @@ def krazykonkat(z: bytes <= 10) -> bytes <= 25:
 
 def test_concat_bytes32():
     test_concat_bytes32 = """
+@public
 def sandwich(inp: bytes <= 100, inp2: bytes32) -> bytes <= 164:
     return concat(inp2, inp, inp2)
 
+@public
 def fivetimes(inp: bytes32) -> bytes <= 160:
     return concat(inp, inp, inp, inp, inp)
     """
@@ -77,14 +83,17 @@ def test_konkat_code():
     konkat_code = """
 ecks: bytes32
 
+@public
 def foo(x: bytes32, y: bytes32) -> bytes <= 64:
     selfecks = x
     return concat(selfecks, y)
 
+@public
 def goo(x: bytes32, y: bytes32) -> bytes <= 64:
     self.ecks = x
     return concat(self.ecks, y)
 
+@public
 def hoo(x: bytes32, y: bytes32) -> bytes <= 64:
     return concat(x, y)
     """

--- a/tests/parser/functions/test_ec.py
+++ b/tests/parser/functions/test_ec.py
@@ -9,14 +9,17 @@ def test_ecadd():
 x3: num256[2]
 y3: num256[2]
 
+@public
 def _ecadd(x: num256[2], y: num256[2]) -> num256[2]:
     return ecadd(x, y)
 
+@public
 def _ecadd2(x: num256[2], y: num256[2]) -> num256[2]:
     x2 = x
     y2 = [y[0], y[1]]
     return ecadd(x2, y2)
 
+@public
 def _ecadd3(x: num256[2], y: num256[2]) -> num256[2]:
     self.x3 = x
     self.y3 = [y[0], y[1]]
@@ -35,14 +38,17 @@ def test_ecmul():
 x3: num256[2]
 y3: num256
 
+@public
 def _ecmul(x: num256[2], y: num256) -> num256[2]:
     return ecmul(x, y)
 
+@public
 def _ecmul2(x: num256[2], y: num256) -> num256[2]:
     x2 = x
     y2 = y
     return ecmul(x2, y2)
 
+@public
 def _ecmul3(x: num256[2], y: num256) -> num256[2]:
     self.x3 = x
     self.y3 = y

--- a/tests/parser/functions/test_ecrecover.py
+++ b/tests/parser/functions/test_ecrecover.py
@@ -5,9 +5,11 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_ecrecover_test():
     ecrecover_test = """
+@public
 def test_ecrecover(h: bytes32, v:num256, r:num256, s:num256) -> address:
     return ecrecover(h, v, r, s)
 
+@public
 def test_ecrecover2() -> address:
     return ecrecover(0x3535353535353535353535353535353535353535353535353535353535353535,
                      as_num256(28),

--- a/tests/parser/functions/test_extract32.py
+++ b/tests/parser/functions/test_extract32.py
@@ -6,13 +6,16 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 def test_extract32_code():
     extract32_code = """
 y: bytes <= 100
+@public
 def extrakt32(inp: bytes <= 100, index: num) -> bytes32:
     return extract32(inp, index)
 
+@public
 def extrakt32_mem(inp: bytes <= 100, index: num) -> bytes32:
     x = inp
     return extract32(x, index)
 
+@public
 def extrakt32_storage(index: num, inp: bytes <= 100) -> bytes32:
     self.y = inp
     return extract32(self.y, index)
@@ -55,18 +58,23 @@ def extrakt32_storage(index: num, inp: bytes <= 100) -> bytes32:
 
 def test_extract32_code():
     extract32_code = """
+@public
 def foo(inp: bytes <= 32) -> num:
     return extract32(inp, 0, type=num128)
 
+@public
 def bar(inp: bytes <= 32) -> num256:
     return extract32(inp, 0, type=num256)
 
+@public
 def baz(inp: bytes <= 32) -> bytes32:
     return extract32(inp, 0, type=bytes32)
 
+@public
 def fop(inp: bytes <= 32) -> bytes32:
     return extract32(inp, 0)
 
+@public
 def foq(inp: bytes <= 32) -> address:
     return extract32(inp, 0, type=address)
     """

--- a/tests/parser/functions/test_is_contract.py
+++ b/tests/parser/functions/test_is_contract.py
@@ -5,12 +5,14 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_is_contract():
     contract_1 = """
+@public
 def foo(arg1: address) -> bool:
     result = arg1.is_contract
     return result
 """
 
     contract_2 = """
+@public
 def foo(arg1: address) -> bool:
     return arg1.is_contract
 """

--- a/tests/parser/functions/test_length.py
+++ b/tests/parser/functions/test_length.py
@@ -6,6 +6,8 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 def test_test_length():
     test_length = """
 y: bytes <= 10
+
+@public
 def foo(inp: bytes <= 10) -> num:
     x = slice(inp, start=1, len=5)
     self.y = slice(inp, start=2, len=4)

--- a/tests/parser/functions/test_method_id.py
+++ b/tests/parser/functions/test_method_id.py
@@ -5,9 +5,11 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_method_id_test():
     method_id_test = """
+@public
 def double(x: num) -> num:
     return x * 2
 
+@public
 def returnten() -> num:
     ans = raw_call(self, concat(method_id("double(int128)"), as_bytes32(5)), gas=50000, outsize=32)
     return as_num128(extract32(ans, 0))

--- a/tests/parser/functions/test_minmax.py
+++ b/tests/parser/functions/test_minmax.py
@@ -5,9 +5,11 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_minmax():
     minmax_test = """
+@public
 def foo() -> decimal:
     return min(3, 5) + max(10, 20) + min(200.1, 400) + max(3000, 8000.02) + min(50000.003, 70000.004)
 
+@public
 def goo() -> num256:
     return num256_add(min(as_num256(3), as_num256(5)), max(as_num256(40), as_num256(80)))
     """

--- a/tests/parser/functions/test_only_init_abi.py
+++ b/tests/parser/functions/test_only_init_abi.py
@@ -5,12 +5,14 @@ def test_only_init_function():
     code = """
 x: num
 
+@public
 def __init__():
     self.x = 1
     """
     code_init_empty = """
 x: num
 
+@public
 def __init__():
     pass
     """

--- a/tests/parser/functions/test_raw_call.py
+++ b/tests/parser/functions/test_raw_call.py
@@ -5,12 +5,15 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_caller_code():
     caller_code = """
+@public
 def foo() -> bytes <= 7:
     return raw_call(0x0000000000000000000000000000000000000004, "moose", gas=50000, outsize=5)
 
+@public
 def bar() -> bytes <= 7:
     return raw_call(0x0000000000000000000000000000000000000004, "moose", gas=50000, outsize=3)
 
+@public
 def baz() -> bytes <= 7:
     return raw_call(0x0000000000000000000000000000000000000004, "moose", gas=50000, outsize=7)
     """
@@ -26,6 +29,7 @@ def baz() -> bytes <= 7:
 
 def test_multiple_levels():
     inner_code = """
+@public
 def returnten() -> num:
     return 10
     """
@@ -33,11 +37,13 @@ def returnten() -> num:
     c = get_contract_with_gas_estimation(inner_code)
 
     outer_code = """
+@public
 def create_and_call_returnten(inp: address) -> num:
     x = create_with_code_of(inp)
     o = extract32(raw_call(x, "\xd0\x1f\xb1\xb8", outsize=32, gas=50000), 0, type=num128)
     return o
 
+@public
 def create_and_return_forwarder(inp: address) -> address:
     return create_with_code_of(inp)
     """
@@ -56,6 +62,7 @@ def create_and_return_forwarder(inp: address) -> address:
 
 def test_multiple_levels2():
     inner_code = """
+@public
 def returnten() -> num:
     assert False
     return 10
@@ -64,11 +71,13 @@ def returnten() -> num:
     c = get_contract_with_gas_estimation(inner_code)
 
     outer_code = """
+@public
 def create_and_call_returnten(inp: address) -> num:
     x = create_with_code_of(inp)
     o = extract32(raw_call(x, "\xd0\x1f\xb1\xb8", outsize=32, gas=50000), 0, type=num128)
     return o
 
+@public
 def create_and_return_forwarder(inp: address) -> address:
     return create_with_code_of(inp)
     """

--- a/tests/parser/functions/test_return_tuple.py
+++ b/tests/parser/functions/test_return_tuple.py
@@ -13,33 +13,41 @@ chunk: {
     c: num
 }
 
+@public
 def __init__():
     self.chunk.a = "hello"
     self.chunk.b = "world"
     self.chunk.c = 5678
 
+@public
 def out() -> (num, address):
     return 3333, 0x0000000000000000000000000000000000000001
 
+@public
 def out_literals() -> (num, address, bytes <= 4):
     return 1, 0x0000000000000000000000000000000000000000, "random"
 
+@public
 def out_bytes_first() -> (bytes <= 4, num):
     return "test", 1234
 
+@public
 def out_bytes_a(x: num, y: bytes <= 4) -> (num, bytes <= 4):
     return x, y
 
+@public
 def out_bytes_b(x: num, y: bytes <= 4) -> (bytes <= 4, num, bytes <= 4):
     return y, x, y
 
+@public
 def four() -> (num, bytes <= 8, bytes <= 8, num):
     return 1234, "bytes", "test", 4321
 
-
+@public
 def out_chunk() -> (bytes <= 8, num, bytes <= 8):
     return self.chunk.a, self.chunk.c, self.chunk.b
 
+@public
 def out_very_long_bytes() -> (num, bytes <= 1024, num, address):
     return 5555, "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest", 6666, 0x0000000000000000000000000000000000001234  # noqa
     """
@@ -58,6 +66,7 @@ def out_very_long_bytes() -> (num, bytes <= 1024, num, address):
 
 def test_return_type_signatures():
     code = """
+@public
 def out_literals() -> (num, address, bytes <= 4):
     return 1, 0x0000000000000000000000000000000000000000, "random"
     """

--- a/tests/parser/functions/test_rlp_list.py
+++ b/tests/parser/functions/test_rlp_list.py
@@ -7,49 +7,61 @@ def test_rlp_decoder_code(assert_tx_failed):
     rlp_decoder_code = """
 u: bytes <= 100
 
+@public
 def foo() -> address:
     x = RLPList('\xf6\x9455555555555555555555\xa0GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG', [address, bytes32])
     return x[0]
 
+@public
 def fop() -> bytes32:
     x = RLPList('\xf6\x9455555555555555555555\xa0GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG', [address, bytes32])
     return x[1]
 
+@public
 def foq() -> bytes <= 100:
     x = RLPList('\xc5\x83cow\x03', [bytes, num])
     return x[0]
 
+@public
 def fos() -> num:
     x = RLPList('\xc5\x83cow\x03', [bytes, num])
     return x[1]
 
+@public
 def fot() -> num256:
     x = RLPList('\xc5\x83cow\x03', [bytes, num256])
     return x[1]
 
+@public
 def qoo(inp: bytes <= 100) -> address:
     x = RLPList(inp, [address, bytes32])
     return x[0]
 
+@public
 def qos(inp: bytes <= 100) -> num:
     x = RLPList(inp, [num, num])
     return x[0] + x[1]
 
+@public
 def qot(inp: bytes <= 100):
     x = RLPList(inp, [num, num])
 
+@public
 def qov(inp: bytes <= 100):
     x = RLPList(inp, [num256, num256])
 
+@public
 def roo(inp: bytes <= 100) -> address:
     self.u = inp
     x = RLPList(self.u, [address, bytes32])
     return x[0]
 
+@public
 def too(inp: bytes <= 100) -> bool:
     x = RLPList(inp, [bool])
     return x[0]
 
+@public
 def voo(inp: bytes <= 1024) -> num:
     x = RLPList(inp, [num, num, bytes32, num, bytes32, bytes])
     return x[1]

--- a/tests/parser/functions/test_send.py
+++ b/tests/parser/functions/test_send.py
@@ -5,10 +5,11 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_send(assert_tx_failed):
     send_test = """
-
+@public
 def foo():
     send(msg.sender, self.balance+1)
 
+@public
 def fop():
     send(msg.sender, 10)
     """

--- a/tests/parser/functions/test_sha3.py
+++ b/tests/parser/functions/test_sha3.py
@@ -5,9 +5,11 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_hash_code():
     hash_code = """
+@public
 def foo(inp: bytes <= 100) -> bytes32:
     return sha3(inp)
 
+@public
 def bar() -> bytes32:
     return sha3("inp")
     """
@@ -21,6 +23,7 @@ def bar() -> bytes32:
 
 def test_hash_code2():
     hash_code2 = """
+@public
 def foo(inp: bytes <= 100) -> bool:
     return sha3(inp) == sha3("badminton")
     """
@@ -32,16 +35,21 @@ def foo(inp: bytes <= 100) -> bool:
 def test_hash_code3():
     hash_code3 = """
 test: bytes <= 100
+
+@public
 def set_test(inp: bytes <= 100):
     self.test = inp
 
+@public
 def tryy(inp: bytes <= 100) -> bool:
     return sha3(inp) == sha3(self.test)
 
+@public
 def trymem(inp: bytes <= 100) -> bool:
     x = self.test
     return sha3(inp) == sha3(x)
 
+@public
 def try32(inp: bytes32) -> bool:
     return sha3(inp) == sha3(self.test)
     """

--- a/tests/parser/functions/test_slice.py
+++ b/tests/parser/functions/test_slice.py
@@ -5,12 +5,15 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_test_slice():
     test_slice = """
+
+@public
 def foo(inp1: bytes <= 10) -> bytes <= 3:
     x = 5
     s = slice(inp1, start=3, len=3)
     y = 7
     return s
 
+@public
 def bar(inp1: bytes <= 10) -> num:
     x = 5
     s = slice(inp1, start=3, len=3)
@@ -29,6 +32,7 @@ def bar(inp1: bytes <= 10) -> num:
 
 def test_test_slice2():
     test_slice2 = """
+@public
 def slice_tower_test(inp1: bytes <= 50) -> bytes <= 50:
     inp = inp1
     for i in range(1, 11):
@@ -48,12 +52,14 @@ def test_test_slice3():
 x: num
 s: bytes <= 50
 y: num
+@public
 def foo(inp1: bytes <= 50) -> bytes <= 50:
     self.x = 5
     self.s = slice(inp1, start=3, len=3)
     self.y = 7
     return self.s
 
+@public
 def bar(inp1: bytes <= 50) -> num:
     self.x = 5
     self.s = slice(inp1, start=3, len=3)
@@ -72,6 +78,7 @@ def bar(inp1: bytes <= 50) -> num:
 
 def test_test_slice4():
     test_slice4 = """
+@public
 def foo(inp: bytes <= 10, start: num, len: num) -> bytes <= 10:
     return slice(inp, start=start, len=len)
     """

--- a/tests/parser/globals/test_getters.py
+++ b/tests/parser/globals/test_getters.py
@@ -7,9 +7,11 @@ def test_state_accessor():
     state_accessor = """
 y: num[num]
 
+@public
 def oo():
     self.y[3] = 5
 
+@public
 def foo() -> num:
     return self.y[3]
 
@@ -36,6 +38,7 @@ w: public({
     g: wei_value
 }[num])
 
+@public
 def __init__():
     self.x = as_wei_value(7, wei)
     self.y[1] = 9

--- a/tests/parser/globals/test_globals.py
+++ b/tests/parser/globals/test_globals.py
@@ -5,10 +5,13 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 def test_permanent_variables_test():
     permanent_variables_test = """
 var: {a: num, b: num}
+
+@public
 def __init__(a: num, b: num):
     self.var.a = a
     self.var.b = b
 
+@public
 def returnMoose() -> num:
     return self.var.a * 10 + self.var.b
     """

--- a/tests/parser/globals/test_setters.py
+++ b/tests/parser/globals/test_setters.py
@@ -7,21 +7,25 @@ def test_multi_setter_test():
     multi_setter_test = """
 foo: num[3]
 bar: num[3][3]
+@public
 def foo() -> num:
     self.foo = [1, 2, 3]
     return(self.foo[0] + self.foo[1] * 10 + self.foo[2] * 100)
 
+@public
 def fop() -> num:
     self.bar[0] = [1, 2, 3]
     self.bar[1] = [4, 5, 6]
     return self.bar[0][0] + self.bar[0][1] * 10 + self.bar[0][2] * 100 + \
         self.bar[1][0] * 1000 + self.bar[1][1] * 10000 + self.bar[1][2] * 100000
 
+@public
 def goo() -> num:
     goo: num[3]
     goo = [1, 2, 3]
     return(goo[0] + goo[1] * 10 + goo[2] * 100)
 
+@public
 def gop() -> num: # Following a standard naming scheme; nothing to do with the US republican party
     gar: num[3][3]
     gar[0] = [1, 2, 3]
@@ -29,21 +33,25 @@ def gop() -> num: # Following a standard naming scheme; nothing to do with the U
     return gar[0][0] + gar[0][1] * 10 + gar[0][2] * 100 + \
         gar[1][0] * 1000 + gar[1][1] * 10000 + gar[1][2] * 100000
 
+@public
 def hoo() -> num:
     self.foo = None
     return(self.foo[0] + self.foo[1] * 10 + self.foo[2] * 100)
 
+@public
 def hop() -> num:
     self.bar[1] = None
     return self.bar[0][0] + self.bar[0][1] * 10 + self.bar[0][2] * 100 + \
         self.bar[1][0] * 1000 + self.bar[1][1] * 10000 + self.bar[1][2] * 100000
 
+@public
 def joo() -> num:
     goo: num[3]
     goo = [1, 2, 3]
     goo = None
     return(goo[0] + goo[1] * 10 + goo[2] * 100)
 
+@public
 def jop() -> num:
     gar: num[3][3]
     gar[0] = [1, 2, 3]
@@ -71,6 +79,7 @@ def test_multi_setter_struct_test():
 foo: {foo: num, bar: num}[3]
 z: {foo: num[3], bar: {a: num, b: num}[2]}[2]
 
+@public
 def foo() -> num:
     self.foo[0] = {foo: 1, bar: 2}
     self.foo[1] = {foo: 3, bar: 4}
@@ -78,6 +87,7 @@ def foo() -> num:
     return self.foo[0].foo + self.foo[0].bar * 10 + self.foo[1].foo * 100 + \
         self.foo[1].bar * 1000 + self.foo[2].foo * 10000 + self.foo[2].bar * 100000
 
+@public
 def fop() -> num:
     self.z = [{foo: [1, 2, 3], bar: [{a: 4, b: 5}, {a: 2, b: 3}]},
               {foo: [6, 7, 8], bar: [{a: 9, b: 1}, {a: 7, b: 8}]}]
@@ -87,6 +97,7 @@ def fop() -> num:
         self.z[1].bar[0].a * 10000000000 + self.z[1].bar[0].b * 100000000000 + \
         self.z[1].bar[1].a * 1000000000000 + self.z[1].bar[1].b * 10000000000000
 
+@public
 def goo() -> num:
     goo: {foo: num, bar: num}[3]
     goo[0] = {foo: 1, bar: 2}
@@ -95,6 +106,7 @@ def goo() -> num:
     return goo[0].foo + goo[0].bar * 10 + goo[1].foo * 100 + \
         goo[1].bar * 1000 + goo[2].foo * 10000 + goo[2].bar * 100000
 
+@public
 def gop() -> num:
     zed = [{foo: [1, 2, 3], bar: [{a: 4, b: 5}, {a: 2, b: 3}]},
            {foo: [6, 7, 8], bar: [{a: 9, b: 1}, {a: 7, b: 8}]}]
@@ -120,11 +132,13 @@ mom: {a: {c: num}[3], b: num}
 non: {a: {c: decimal}[3], b:num}
 pap: decimal[2][2]
 
+@public
 def foo() -> num:
     self.mom = {a: [{c: 1}, {c: 2}, {c: 3}], b: 4}
     self.non = self.mom
     return floor(self.non.a[0].c + self.non.a[1].c * 10 + self.non.a[2].c * 100 + self.non.b * 1000)
 
+@public
 def goo() -> num:
     self.pap = [[1, 2], [3, 4.0]]
     return floor(self.pap[0][0] + self.pap[0][1] * 10 + self.pap[1][0] * 100 + self.pap[1][1] * 1000)
@@ -140,6 +154,8 @@ def test_composite_setter_test():
     composite_setter_test = """
 mom: {a: {c: num}[3], b:num}
 qoq: {c: num}
+
+@public
 def foo() -> num:
     self.mom = {a: [{c: 1}, {c: 2}, {c: 3}], b: 4}
     non = {c: 5}
@@ -148,6 +164,7 @@ def foo() -> num:
     self.mom.a[2] = non
     return self.mom.a[0].c + self.mom.a[1].c * 10 + self.mom.a[2].c * 100 + self.mom.b * 1000
 
+@public
 def fop() -> num:
     popp = {a: [{c: 1}, {c: 2}, {c: 3}], b: 4}
     self.qoq = {c: 5}
@@ -156,6 +173,7 @@ def fop() -> num:
     popp.a[2] = self.qoq
     return popp.a[0].c + popp.a[1].c * 10 + popp.a[2].c * 100 + popp.b * 1000
 
+@public
 def foq() -> num:
     popp = {a: [{c: 1}, {c: 2}, {c: 3}], b: 4}
     popp.a[0] = None

--- a/tests/parser/integration/test_basics.py
+++ b/tests/parser/integration/test_basics.py
@@ -5,6 +5,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_null_code():
     null_code = """
+@public
 def foo():
     pass
     """
@@ -15,7 +16,7 @@ def foo():
 
 def test_basic_code():
     basic_code = """
-
+@public
 def foo(x: num) -> num:
     return x * 2
 
@@ -27,15 +28,19 @@ def foo(x: num) -> num:
 
 def test_selfcall_code_3():
     selfcall_code_3 = """
+@public
 def _hashy2(x: bytes <= 100) -> bytes32:
     return sha3(x)
 
+@public
 def return_hash_of_cow_x_30() -> bytes32:
     return self._hashy2("cowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcowcow")
 
+@public
 def _len(x: bytes <= 100) -> num:
     return len(x)
 
+@public
 def returnten() -> num:
     return self._len("badminton!")
     """

--- a/tests/parser/integration/test_crowdfund.py
+++ b/tests/parser/integration/test_crowdfund.py
@@ -14,12 +14,14 @@ goal: wei_value
 refundIndex: num
 timelimit: timedelta
 
+@public
 def __init__(_beneficiary: address, _goal: wei_value, _timelimit: timedelta):
     self.beneficiary = _beneficiary
     self.deadline = block.timestamp + _timelimit
     self.timelimit = _timelimit
     self.goal = _goal
 
+@public
 @payable
 def participate():
     assert block.timestamp < self.deadline
@@ -28,30 +30,37 @@ def participate():
     self.funders[nfi].value = msg.value
     self.nextFunderIndex = nfi + 1
 
+@public
 @constant
 def expired() -> bool:
     return block.timestamp >= self.deadline
 
+@public
 @constant
 def timestamp() -> timestamp:
     return block.timestamp
 
+@public
 @constant
 def deadline() -> timestamp:
     return self.deadline
 
+@public
 @constant
 def timelimit() -> timedelta:
     return self.timelimit
 
+@public
 @constant
 def reached() -> bool:
     return self.balance >= self.goal
 
+@public
 def finalize():
     assert block.timestamp >= self.deadline and self.balance >= self.goal
     selfdestruct(self.beneficiary)
 
+@public
 def refund():
     ind = self.refundIndex
     for i in range(ind, ind + 30):
@@ -108,12 +117,14 @@ goal: wei_value
 refundIndex: num
 timelimit: timedelta
 
+@public
 def __init__(_beneficiary: address, _goal: wei_value, _timelimit: timedelta):
     self.beneficiary = _beneficiary
     self.deadline = block.timestamp + _timelimit
     self.timelimit = _timelimit
     self.goal = _goal
 
+@public
 @payable
 def participate():
     assert block.timestamp < self.deadline
@@ -121,30 +132,37 @@ def participate():
     self.funders[nfi] = {sender: msg.sender, value: msg.value}
     self.nextFunderIndex = nfi + 1
 
+@public
 @constant
 def expired() -> bool:
     return block.timestamp >= self.deadline
 
+@public
 @constant
 def timestamp() -> timestamp:
     return block.timestamp
 
+@public
 @constant
 def deadline() -> timestamp:
     return self.deadline
 
+@public
 @constant
 def timelimit() -> timedelta:
     return self.timelimit
 
+@public
 @constant
 def reached() -> bool:
     return self.balance >= self.goal
 
+@public
 def finalize():
     assert block.timestamp >= self.deadline and self.balance >= self.goal
     selfdestruct(self.beneficiary)
 
+@public
 def refund():
     ind = self.refundIndex
     for i in range(ind, ind + 30):

--- a/tests/parser/integration/test_escrow.py
+++ b/tests/parser/integration/test_escrow.py
@@ -9,16 +9,19 @@ buyer: address
 seller: address
 arbitrator: address
 
+@public
 def setup(_seller: address, _arbitrator: address):
     if not self.buyer:
         self.buyer = msg.sender
         self.seller = _seller
         self.arbitrator = _arbitrator
 
+@public
 def finalize():
     assert msg.sender == self.buyer or msg.sender == self.arbitrator
     send(self.seller, self.balance)
 
+@public
 def refund():
     assert msg.sender == self.seller or msg.sender == self.arbitrator
     send(self.buyer, self.balance)
@@ -44,6 +47,7 @@ buyer: address
 seller: address
 arbitrator: address
 
+@public
 @payable
 def __init__(_seller: address, _arbitrator: address):
     if not self.buyer:
@@ -51,10 +55,12 @@ def __init__(_seller: address, _arbitrator: address):
         self.seller = _seller
         self.arbitrator = _arbitrator
 
+@public
 def finalize():
     assert msg.sender == self.buyer or msg.sender == self.arbitrator
     send(self.seller, self.balance)
 
+@public
 def refund():
     assert msg.sender == self.seller or msg.sender == self.arbitrator
     send(self.buyer, self.balance)

--- a/tests/parser/syntax/test_as_num256.py
+++ b/tests/parser/syntax/test_as_num256.py
@@ -7,10 +7,12 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def convert2(inp: num256) -> address:
     return as_bytes32(inp)
     """,
     """
+@public
 def modtest(x: num256, y: num) -> num256:
     return x % y
     """
@@ -26,14 +28,17 @@ def test_as_wei_fail(bad_code):
 
 valid_list = [
     """
+@public
 def convert1(inp: bytes32) -> num256:
     return as_num256(inp)
     """,
     """
+@public
 def convert1(inp: bytes32) -> num256:
     return as_num256(inp)
     """,
     """
+@public
 def convert2(inp: num256) -> bytes32:
     return as_bytes32(inp)
     """

--- a/tests/parser/syntax/test_as_wei.py
+++ b/tests/parser/syntax/test_as_wei.py
@@ -7,10 +7,12 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo():
     x = as_wei_value(5, 'szabo')
     """,
     """
+@public
 def foo() -> num(wei):
     x = 45
     return x.balance
@@ -27,19 +29,23 @@ def test_as_wei_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo():
     x = as_wei_value(5, finney) + as_wei_value(2, babbage) + as_wei_value(8, shannon)
     """,
     """
+@public
 def foo():
     z = 2 + 3
     x = as_wei_value(2 + 3, finney)
     """,
     """
+@public
 def foo():
     x = as_wei_value(5.182, ada)
     """,
     """
+@public
 def foo() -> num(wei):
     x = 0x1234567890123456789012345678901234567890
     return x.balance

--- a/tests/parser/syntax/test_block.py
+++ b/tests/parser/syntax/test_block.py
@@ -7,64 +7,77 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo() -> num:
     x = create_with_code_of(0x1234567890123456789012345678901234567890, value=block.timestamp)
     return 5
     """,
     """
+@public
 def foo() -> num[2]:
     return [3,block.timestamp]
     """,
     """
+@public
 def foo() -> timedelta[2]:
     return [block.timestamp - block.timestamp, block.timestamp]
     """,
     """
+@public
 def foo() -> num(wei / sec):
     x = as_wei_value(5, finney)
     y = block.timestamp + 50
     return x / y
     """,
     """
+@public
 def foo():
     x = slice("cow", start=0, len=block.timestamp)
     """,
     """
+@public
 def foo():
     x = 7
     y = min(x, block.timestamp)
     """,
     """
+@public
 def foo():
     y = min(block.timestamp + 30 - block.timestamp, block.timestamp)
     """,
     """
 a: num[timestamp]
 
+@public
 def add_record():
     self.a[block.timestamp] = block.timestamp + 20
     """,
     """
 a: timestamp[num]
 
+@public
 def add_record():
     self.a[block.timestamp] = block.timestamp + 20
     """,
     """
+@public
 def add_record():
     a = {x: block.timestamp}
     b = {y: 5}
     a.x = b.y
     """,
     """
+@public
 def foo(inp: bytes <= 10) -> bytes <= 3:
     return slice(inp, start=block.timestamp, len=3)
     """,
     """
+@public
 def foo() -> address:
     return as_unitless_number(block.coinbase)
     """,
     ("""
+@public
 def foo() -> num:
     return block.fail
 """, Exception)
@@ -86,33 +99,41 @@ valid_list = [
     """
 a: timestamp[timestamp]
 
+
+@public
 def add_record():
     self.a[block.timestamp] = block.timestamp + 20
     """,
     """
+@public
 def foo() -> num(wei / sec):
     x = as_wei_value(5, finney)
     y = block.timestamp + 50 - block.timestamp
     return x / y
     """,
     """
+@public
 def foo() -> timestamp[2]:
     return [block.timestamp + 86400, block.timestamp]
     """,
     """
+@public
 def foo():
     y = min(block.timestamp + 30, block.timestamp + 50)
     """,
     """
+@public
 def foo() -> num:
     return as_unitless_number(block.timestamp)
     """,
     """
+@public
 def add_record():
     a = {x: block.timestamp}
     a.x = 5
     """,
     """
+@public
 def foo():
     x = block.difficulty + 185
     if tx.origin == self:

--- a/tests/parser/syntax/test_bool.py
+++ b/tests/parser/syntax/test_bool.py
@@ -7,24 +7,29 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo():
     x = true
     x = 5
     """,
     ("""
+@public
 def foo():
     True = 3
     """, SyntaxError),
     """
+@public
 def foo():
     x = True
     x = 129
     """,
     """
+@public
 def foo() -> bool:
     return (1 == 2) <= (1 == 1)
     """,
     """
+@public
 def foo() -> bool:
     return (1 == 2) or 3
     """
@@ -44,41 +49,50 @@ def test_bool_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo():
     x = true
     z = x and false
     """,
     """
+@public
 def foo():
     x = true
     z = x and False
     """,
     """
+@public
 def foo():
     x = True
     x = False
     """,
     """
+@public
 def foo() -> bool:
     return 1 == 1
     """,
     """
+@public
 def foo() -> bool:
     return 1 != 1
     """,
     """
+@public
 def foo() -> bool:
     return 1 > 1
     """,
     """
+@public
 def foo() -> bool:
     return 1. >= 1
     """,
     """
+@public
 def foo() -> bool:
     return 1 < 1
     """,
     """
+@public
 def foo() -> bool:
     return 1 <= 1.
     """

--- a/tests/parser/syntax/test_byte_string.py
+++ b/tests/parser/syntax/test_byte_string.py
@@ -7,10 +7,12 @@ from viper.exceptions import TypeMismatchException
 
 valid_list = [
     """
+@public
 def foo() -> bytes <= 10:
     return "badminton"
     """,
     """
+@public
 def foo():
     x = "¡très bien!"
     """

--- a/tests/parser/syntax/test_bytes.py
+++ b/tests/parser/syntax/test_bytes.py
@@ -7,47 +7,56 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def baa():
     x: bytes <= 50
     y: bytes <= 50
     z = x + y
     """,
     """
+@public
 def baa():
     x: bytes <= 50
     y: num
     y = x
     """,
     """
+@public
 def baa():
     x: bytes <= 50
     y: num
     x = y
     """,
     """
+@public
 def baa():
     x: bytes <= 50
     y: bytes <= 60
     x = y
     """,
     """
+@public
 def foo(x: bytes <= 100) -> bytes <= 75:
     return x
     """,
     """
+@public
 def foo(x: bytes <= 100) -> num:
     return x
     """,
     """
+@public
 def foo(x: num) -> bytes <= 75:
     return x
     """,
     """
+@public
 def foo() -> bytes <= 10:
     x = '0x1234567890123456789012345678901234567890'
     x = 0x1234567890123456789012345678901234567890
     """,
     """
+@public
 def foo() -> bytes <= 10:
     return "badmintonzz"
     """
@@ -63,18 +72,22 @@ def test_bytes_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo(x: bytes <= 100) -> bytes <= 100:
     return x
     """,
     """
+@public
 def foo(x: bytes <= 100) -> bytes <= 150:
     return x
     """,
     """
+@public
 def convert2(inp: num256) -> bytes32:
     return as_bytes32(inp)
     """,
     """
+@public
 def baa():
     x: bytes <= 50
     """

--- a/tests/parser/syntax/test_code_size.py
+++ b/tests/parser/syntax/test_code_size.py
@@ -7,11 +7,13 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo() -> num:
     x = 45
     return x.codesize
     """,
     """
+@public
 def foo() -> num(wei):
     x = 0x1234567890123456789012345678901234567890
     return x.codesize
@@ -28,6 +30,7 @@ def test_block_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo() -> num:
     x = 0x1234567890123456789012345678901234567890
     return x.codesize

--- a/tests/parser/syntax/test_concat.py
+++ b/tests/parser/syntax/test_concat.py
@@ -7,26 +7,31 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def cat(i1: bytes <= 10, i2: bytes <= 30) -> bytes <= 40:
     return concat(i1, i2, i1, i1)
     """,
     """
+@public
 def cat(i1: bytes <= 10, i2: bytes <= 30) -> bytes <= 40:
     return concat(i1, 5)
     """,
     """
+@public
 def sandwich(inp: bytes <= 100, inp2: bytes32) -> bytes <= 163:
     return concat(inp2, inp, inp2)
     """,
     """
 y: bytes <= 10
 
+@public
 def krazykonkat(z: bytes <= 10) -> bytes <= 24:
     x = "cow"
     self.y = "horse"
     return concat(x, " ", self.y, " ", z)
     """,
     """
+@public
 def cat_list(y: num) -> bytes <= 40:
     x = [y]
     return concat("test", y)
@@ -35,24 +40,29 @@ def cat_list(y: num) -> bytes <= 40:
 
 valid_list = [
     """
+@public
 def cat(i1: bytes <= 10, i2: bytes <= 30) -> bytes <= 40:
     return concat(i1, i2)
     """,
     """
+@public
 def cat(i1: bytes <= 10, i2: bytes <= 30) -> bytes <= 40:
     return concat(i1, i1, i1, i1)
     """,
     """
+@public
 def cat(i1: bytes <= 10, i2: bytes <= 30) -> bytes <= 40:
     return concat(i1, i1)
     """,
     """
+@public
 def sandwich(inp: bytes <= 100, inp2: bytes32) -> bytes <= 165:
     return concat(inp2, inp, inp2)
     """,
     """
 y: bytes <= 10
 
+@public
 def krazykonkat(z: bytes <= 10) -> bytes <= 25:
     x = "cow"
     self.y = "horse"

--- a/tests/parser/syntax/test_create_with_code_of.py
+++ b/tests/parser/syntax/test_create_with_code_of.py
@@ -6,6 +6,7 @@ from viper import compiler
 
 fail_list = [
     """
+@public
 def foo():
     x = create_with_code_of(0x1234567890123456789012345678901234567890, value=4, value=9)
     """
@@ -20,14 +21,17 @@ def test_type_mismatch_exception(bad_code):
 
 valid_list = [
     """
+@public
 def foo():
     x = create_with_code_of(0x1234567890123456789012345678901234567890)
     """,
     """
+@public
 def foo():
     x = create_with_code_of(0x1234567890123456789012345678901234567890, value=as_wei_value(9, wei))
     """,
     """
+@public
 def foo():
     x = create_with_code_of(0x1234567890123456789012345678901234567890, value=9)
     """

--- a/tests/parser/syntax/test_extract32.py
+++ b/tests/parser/syntax/test_extract32.py
@@ -6,6 +6,7 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo() -> num256:
     return extract32("cowcowcowcowcowccowcowcowcowcowccowcowcowcowcowccowcowcowcowcowc", 0)
     """
@@ -21,17 +22,20 @@ def test_extract32_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo() -> num256:
     return extract32("cowcowcowcowcowccowcowcowcowcowccowcowcowcowcowccowcowcowcowcowc", 0, type=num256)
     """,
     """
 x: bytes <= 100
+@public
 def foo() -> num256:
     self.x = "cowcowcowcowcowccowcowcowcowcowccowcowcowcowcowccowcowcowcowcowc"
     return extract32(self.x, 0, type=num256)
     """,
     """
 x: bytes <= 100
+@public
 def foo() -> num256:
     self.x = "cowcowcowcowcowccowcowcowcowcowccowcowcowcowcowccowcowcowcowcowc"
     return extract32(self.x, 1, type=num256)

--- a/tests/parser/syntax/test_for_range.py
+++ b/tests/parser/syntax/test_for_range.py
@@ -4,16 +4,19 @@ from viper import compiler
 
 valid_list = [
     """
+@public
 def foo():
     for i in range(10):
         pass
     """,
     """
+@public
 def foo():
     for i in range(10, 20):
         pass
     """,
     """
+@public
 def foo():
     x = 5
     for i in range(x, x + 10):

--- a/tests/parser/syntax/test_invalids.py
+++ b/tests/parser/syntax/test_invalids.py
@@ -29,33 +29,39 @@ x: num[3]
 """)
 
 must_succeed("""
+@public
 def foo(x: num): pass
 """)
 
 must_succeed("""
+@public
 def foo():
     x: num
     x = 5
 """)
 
 must_succeed("""
+@public
 def foo():
     x = 5
 """)
 
 must_fail("""
+@public
 def foo():
     x = 5
     x = 0x1234567890123456789012345678901234567890
 """, TypeMismatchException)
 
 must_fail("""
+@public
 def foo():
     x = 5
     x = 3.5
 """, TypeMismatchException)
 
 must_succeed("""
+@public
 def foo():
     x = 5
     x = 3
@@ -63,71 +69,83 @@ def foo():
 
 must_succeed("""
 b: num
+@public
 def foo():
     self.b = 7
 """)
 
 must_fail("""
 b: num
+@public
 def foo():
     self.b = 7.5
 """, TypeMismatchException)
 
 must_succeed("""
 b: decimal
+@public
 def foo():
     self.b = 7.5
 """)
 
 must_succeed("""
 b: decimal
+@public
 def foo():
     self.b = 7
 """)
 
 must_fail("""
 b: num[5]
+@public
 def foo():
     self.b = 7
 """, TypeMismatchException)
 
 must_succeed("""
 b: num[num]
+@public
 def foo():
     x = self.b[5]
 """)
 
 must_fail("""
 b: num[num]
+@public
 def foo():
     x = self.b[5.7]
 """, TypeMismatchException)
 
 must_succeed("""
 b: num[decimal]
+@public
 def foo():
     x = self.b[5]
 """)
 
 must_fail("""
 b: num[num]
+@public
 def foo():
     self.b[3] = 5.6
 """, TypeMismatchException)
 
 must_succeed("""
 b: num[num]
+@public
 def foo():
     self.b[3] = -5
 """)
 
 must_succeed("""
 b: num[num]
+@public
 def foo():
     self.b[-3] = 5
 """)
 
 must_succeed("""
+@public
 def foo():
     x: num[5]
     z = x[2]
@@ -135,6 +153,7 @@ def foo():
 
 must_succeed("""
 x: num
+@public
 def foo() -> num:
     self.x = 5
 """)
@@ -148,60 +167,72 @@ def foo() -> num:
 
 must_fail("""
 foo: num[3]
+@public
 def foo():
     self.foo = 5
 """, TypeMismatchException)
 
 must_succeed("""
 foo: num[3]
+@public
 def foo():
     self.foo[0] = 5
 """)
 
 must_fail("""
+@public
 def foo() -> address:
     return as_unitless_number([1, 2, 3])
 """, TypeMismatchException)
 
 must_succeed("""
+@public
 def foo(x: wei_value, y: currency_value, z: num (wei*currency/sec**2)) -> num (sec**2):
     return x * y / z
 """)
 
 must_fail("""
+@public
 def baa() -> decimal:
     return 2.0**2
 """, TypeMismatchException)
 
 must_succeed("""
+@public
 def foo():
     throw
 """)
 
 must_succeed("""
+@public
 def foo():
     pass
 
+@public
 def goo():
     self.foo()
 """)
 
 must_succeed("""
+@public
 def foo():
     MOOSE = 45
 """)
 
 must_fail("""
+@public
 def foo():
     x = -self
 """, TypeMismatchException)
 
 must_fail("""
+@public
 def foo() -> num:
     return
 """, TypeMismatchException)
 
 must_fail("""
+@public
 def foo():
     return 3
 """, TypeMismatchException)

--- a/tests/parser/syntax/test_len.py
+++ b/tests/parser/syntax/test_len.py
@@ -7,10 +7,12 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo(inp: num) -> num:
     return len(inp)
     """,
     """
+@public
 def foo(inp: num) -> address:
     return len(inp)
     """
@@ -30,6 +32,7 @@ def test_block_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo(inp: bytes <= 10) -> num:
     return len(inp)
     """

--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -7,88 +7,105 @@ from viper.exceptions import TypeMismatchException, StructureException
 
 fail_list = [
     """
+@public
 def foo():
     x = [1, 2, 3]
     x = 4
     """,
     """
+@public
 def foo():
     x = [1, 2, 3]
     x = [4, 5, 6, 7]
     """,
     """
+@public
 def foo() -> num[2]:
     return [3,5,7]
     """,
     """
+@public
 def foo() -> num[2]:
     return [3]
     """,
     """
 y: num[3]
 
+@public
 def foo(x: num[3]) -> num:
     self.y = x[0]
     """,
     """
 y: num[3]
 
+@public
 def foo(x: num[3]) -> num:
     self.y[0] = x
     """,
     """
 y: num[4]
 
+@public
 def foo(x: num[3]) -> num:
     self.y = x
     """,
     """
 foo: num[3]
+@public
 def foo():
     self.foo = [1, 2, 0x1234567890123456789012345678901234567890]
     """,
     ("""
 foo: num[3]
+@public
 def foo():
     self.foo = []
     """, StructureException),
     """
 b: num[5]
+@public
 def foo():
     x = self.b[0][1]
     """,
     """
 foo: num[3]
+@public
 def foo():
     self.foo = [1, [2], 3]
     """,
     """
 bar: num[3][3]
+@public
 def foo():
     self.bar = 5
     """,
     """
 bar: num[3][3]
+@public
 def foo():
     self.bar = [2, 5]
     """,
     """
 foo: num[3]
+@public
 def foo():
     self.foo = [1, 2, 3, 4]
     """,
     """
 foo: num[3]
+@public
 def foo():
     self.foo = [1, 2]
     """,
     """
 b: num[5]
+@public
 def foo():
     self.b[0] = 7.5
     """,
     """
 b: num[5]
+@public
 def foo():
     x = self.b[0].cow
     """,
@@ -108,56 +125,67 @@ def test_block_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo():
     x = [1, 2, 3]
     x = [4, 5, 6]
     """,
     """
+@public
 def foo() -> num[2][2]:
     return [[1,2],[3,4]]
     """,
     """
+@public
 def foo() -> decimal[2][2]:
     return [[1,2],[3,4]]
     """,
     """
+@public
 def foo() -> decimal[2][2]:
     return [[1,2.0],[3.5,4]]
     """,
     """
+@public
 def foo(x: num[3]) -> num:
     return x[0]
     """,
     """
 y: num[3]
 
+@public
 def foo(x: num[3]) -> num:
     self.y = x
     """,
     """
 y: decimal[3]
 
+@public
 def foo(x: num[3]) -> num:
     self.y = x
     """,
     """
 y: decimal[2][2]
 
+@public
 def foo(x: num[2][2]) -> num:
     self.y = x
     """,
     """
 y: decimal[2]
 
+@public
 def foo(x: num[2][2]) -> num:
     self.y = x[1]
     """,
     """
+@public
 def foo() -> num[2]:
     return [3,5]
     """,
     """
 foo: decimal[3]
+@public
 def foo():
     self.foo = [1, 2.1, 3]
     """,
@@ -166,17 +194,20 @@ x: num[1][2][3][4][5]
     """,
     """
 foo: num[3]
+@public
 def foo():
     self.foo = [1, 2, 3]
     """,
     """
 b: num[5]
+@public
 def foo():
     a: num[5]
     self.b[0] = a[0]
     """,
     """
 b: decimal[5]
+@public
 def foo():
     self.b[0] = 7
     """

--- a/tests/parser/syntax/test_maps.py
+++ b/tests/parser/syntax/test_maps.py
@@ -9,98 +9,116 @@ fail_list = [
     """
 mom: {a: {c: num}[3], b: num}
 nom: {a: {c: num}[2], b: num}
+@public
 def foo():
     self.nom = self.mom
     """,
     """
 mom: {a: {c: num}[3], b: num}
 nom: {a: {c: decimal}[2], b: num}
+@public
 def foo():
     self.nom = self.mom
     """,
     """
 mom: {a: {c: num}[3], b: num}
 nom: {a: {c: num}[3], b: num, c: num}
+@public
 def foo():
     self.nom = self.mom
     """,
     """
 mom: {a: {c: num}[3], b: num}
 nom: {a: {c: num}[3]}
+@public
 def foo():
     self.nom = self.mom
     """,
     """
 mom: {a: {c: num}[3], b: num}
 nom: {a: {c: num}, b: num}
+@public
 def foo():
     self.nom = self.mom
     """,
     """
 mom: {a: {c: num}[3], b: num}
 nom: {c: num}[3]
+@public
 def foo():
     self.nom = self.mom.b
     """,
     """
 mom: {a: {c: num}[3], b: num}
 nom: {c: num}[3]
+@public
 def foo():
     self.mom = {a: self.nom, b: 5.5}
     """,
     """
 mom: {a: {c: num}[3], b: num}
 nom: {c: decimal}[3]
+@public
 def foo():
     self.mom = {a: self.nom, b: 5}
     """,
     """
 mom: {a: {c: num}[3], b: num}
 nom: {c: num}[3]
+@public
 def foo():
     self.mom = {a: self.nom, b: self.nom}
     """,
     """
 nom: {a: {c: num}[num], b: num}
+@public
 def foo():
     self.nom = None
     """,
     """
 nom: {a: {c: num}[num], b: num}
+@public
 def foo():
     self.nom = {a: [{c: 5}], b: 7}
     """,
     """
 foo: num[3]
+@public
 def foo():
     self.foo = {0: 5, 1: 7, 2: 9}
     """,
     """
 foo: num[3]
+@public
 def foo():
     self.foo = {a: 5, b: 7, c: 9}
     """,
     """
+@public
 def foo() -> num:
     return {cow: 5, dog: 7}
     """,
     """
 x: {cow: num, cor: num}
+@public
 def foo():
     self.x.cof = 1
     """,
     """
 b: {foo: num}
+@public
 def foo():
     self.b = {foo: 1, foo: 2}
     """,
     """
 b: {foo: num, bar: num}
+@public
 def foo():
     x = self.b.cow
     """,
     """
 b: {foo: num, bar: num}
+@public
 def foo():
     x = self.b[0]
     """,
@@ -117,23 +135,27 @@ valid_list = [
     """
 mom: {a: {c: num}[3], b: num}
 nom: {a: {c: decimal}[3], b: num}
+@public
 def foo():
     self.nom = self.mom
     """,
     """
 mom: {a: {c: num}[3], b: num}
 nom: {c: num}[3]
+@public
 def foo():
     self.nom = self.mom.a
     """,
     """
 nom: {a: {c: num}[num], b: num}
+@public
 def foo():
     self.nom.a[135] = {c: 6}
     self.nom.b = 9
     """,
     """
 nom: {c: num}[3]
+@public
 def foo():
     mom: {a: {c: num}[3], b: num}
     mom.a = self.nom
@@ -141,17 +163,20 @@ def foo():
     """
 mom: {a: {c: num}[3], b: num}
 nom: {c: num}[3]
+@public
 def foo():
     self.mom = {a: self.nom, b: 5}
     """,
     """
 mom: {a: {c: num}[3], b: num}
 nom: {c: num}[3]
+@public
 def foo():
     self.mom = {a: null, b: 5}
     """,
     """
 mom: {a: {c: num}[3], b: num}
+@public
 def foo():
     nom: {c: num}[3]
     self.mom = {a: nom, b: 5}
@@ -159,11 +184,13 @@ def foo():
     """
 mom: {a: {c: decimal}[3], b: num}
 nom: {c: num}[3]
+@public
 def foo():
     self.mom = {a: self.nom, b: 5}
     """,
     """
 b: {foo: num, bar: num}
+@public
 def foo():
     x = self.b.bar
     """,

--- a/tests/parser/syntax/test_minmax.py
+++ b/tests/parser/syntax/test_minmax.py
@@ -7,10 +7,12 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo():
     y = min(7, 0x1234567890123456789012345678901234567890)
     """,
     """
+@public
 def foo():
     y = min(7, as_num256(3))
     """

--- a/tests/parser/syntax/test_nested_list.py
+++ b/tests/parser/syntax/test_nested_list.py
@@ -8,31 +8,37 @@ from viper.exceptions import TypeMismatchException, StructureException
 fail_list = [
     """
 bar: num[3][3]
+@public
 def foo():
     self.bar = [[1, 2], [3, 4, 5], [6, 7, 8]]
     """,
     """
 bar: num[3][3]
+@public
 def foo():
     self.bar = [[1, 2, 3], [4, 5, 6], [7, 8, 9.0]]
     """,
     """
+@public
 def foo() -> num[2]:
     return [[1,2],[3,4]]
     """,
     """
+@public
 def foo() -> num[2][2]:
     return [1,2]
     """,
     """
 y: address[2][2]
 
+@public
 def foo(x: num[2][2]) -> num:
     self.y = x
     """,
     ("""
 bar: num[3][3]
 
+@public
 def foo() -> num[3]:
     self.bar = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     for x in self.bar:
@@ -56,11 +62,13 @@ def test_nested_list_fail(bad_code):
 valid_list = [
     """
 bar: num[3][3]
+@public
 def foo():
     self.bar = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     """,
     """
 bar: decimal[3][3]
+@public
 def foo():
     self.bar = [[1, 2, 3], [4, 5, 6], [7, 8, 9.0]]
     """

--- a/tests/parser/syntax/test_public.py
+++ b/tests/parser/syntax/test_public.py
@@ -12,6 +12,7 @@ x: public(num(wei / sec))
 y: public(num(wei / sec ** 2))
 z: public(num(1 / sec))
 
+@public
 def foo() -> num(sec ** 2):
     return self.x / self.y / self.z
     """

--- a/tests/parser/syntax/test_raw_call.py
+++ b/tests/parser/syntax/test_raw_call.py
@@ -7,14 +7,17 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     ("""
+@public
 def foo():
     x = raw_call(0x1234567890123456789012345678901234567890, "cow", outsize=4, outsize=9)
     """, SyntaxError),
     """
+@public
 def foo():
     raw_log(["cow"], "dog")
     """,
     """
+@public
 def foo():
     raw_log([], 0x1234567890123456789012345678901234567890)
     """
@@ -34,14 +37,17 @@ def test_raw_call_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo():
     x = raw_call(0x1234567890123456789012345678901234567890, "cow", outsize=4, gas=595757)
     """,
     """
+@public
 def foo():
     x = raw_call(0x1234567890123456789012345678901234567890, "cow", outsize=4, gas=595757, value=as_wei_value(9, wei))
     """,
     """
+@public
 def foo():
     x = raw_call(0x1234567890123456789012345678901234567890, "cow", outsize=4, gas=595757, value=9)
     """

--- a/tests/parser/syntax/test_return_tuple.py
+++ b/tests/parser/syntax/test_return_tuple.py
@@ -7,6 +7,7 @@ from viper.exceptions import StructureException
 
 fail_list = [
     """
+@public
 def unmatched_tupl_length() -> (bytes <= 8, num, bytes <= 8):
     return "test", 123
     """

--- a/tests/parser/syntax/test_rlplist.py
+++ b/tests/parser/syntax/test_rlplist.py
@@ -7,26 +7,31 @@ from viper.exceptions import TypeMismatchException, StructureException
 
 fail_list = [
     """
+@public
 def foo() -> address:
     x = RLPList('\xf6\x9455555555555555555555\xa0GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG', [address, bytes32])
     return x[1]
     """,
     """
+@public
 def foo() -> address:
     x = RLPList('\xf6\x9455555555555555555555\xa0GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG', [address, bytes32])
     return x[2]
     """,
     """
+@public
 def foo() -> bytes <= 500:
     x = RLPList('\xe1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', [bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes])
     return x[1]
     """,
     ("""
+@public
 def foo() -> bytes <= 500:
     x = 1
     return RLPList('\xe0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
     """, StructureException),
     """
+@public
 def foo() -> bytes <= 500:
     x = [1, 2, 3]
     return RLPList(x, [bytes])
@@ -47,16 +52,19 @@ def test_rlplist_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo() -> bytes <= 500:
     x = RLPList('\xe0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', [bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes, bytes])
     return x[1]
     """,
     """
+@public
 def foo() -> address:
     x = RLPList('\xf6\x9455555555555555555555\xa0GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG', [address, bytes32])
     return x[0]
     """,
     """
+@public
 def foo() -> bytes32:
     x = RLPList('\xf6\x9455555555555555555555\xa0GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG', [address, bytes32])
     return x[1]

--- a/tests/parser/syntax/test_selfdestruct.py
+++ b/tests/parser/syntax/test_selfdestruct.py
@@ -7,6 +7,7 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo():
     selfdestruct(7)
     """
@@ -22,6 +23,7 @@ def test_block_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo():
     selfdestruct(0x1234567890123456789012345678901234567890)
     """

--- a/tests/parser/syntax/test_send.py
+++ b/tests/parser/syntax/test_send.py
@@ -7,36 +7,43 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo():
     send(1, 2)
     """,
     """
+@public
 def foo():
     send(1, 2)
     """,
     """
+@public
 def foo():
     send(0x1234567890123456789012345678901234567890, 2.5)
     """,
     """
+@public
 def foo():
     send(0x1234567890123456789012345678901234567890, 0x1234567890123456789012345678901234567890)
     """,
     """
 x: num
 
+@public
 def foo():
     send(0x1234567890123456789012345678901234567890, self.x)
     """,
     """
 x: wei_value
 
+@public
 def foo():
     send(0x1234567890123456789012345678901234567890, self.x + 1.5)
     """,
     """
 x: decimal
 
+@public
 def foo():
     send(0x1234567890123456789012345678901234567890, self.x)
     """
@@ -53,22 +60,26 @@ valid_list = [
     """
 x: wei_value
 
+@public
 def foo():
     send(0x1234567890123456789012345678901234567890, self.x + 1)
     """,
     """
 x: decimal
 
+@public
 def foo():
     send(0x1234567890123456789012345678901234567890, as_wei_value(floor(self.x), wei))
     """,
     """
 x: wei_value
 
+@public
 def foo():
     send(0x1234567890123456789012345678901234567890, self.x)
     """,
     """
+@public
 def foo():
     send(0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe, 5)
     """

--- a/tests/parser/syntax/test_sha3.py
+++ b/tests/parser/syntax/test_sha3.py
@@ -7,6 +7,7 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo():
     x = sha3(3)
     """
@@ -21,10 +22,12 @@ def test_block_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo():
     x = sha3("moose")
     """,
     """
+@public
 def foo():
     x = sha3(0x1234567890123456789012345678901234567890123456789012345678901234)
     """

--- a/tests/parser/syntax/test_slice.py
+++ b/tests/parser/syntax/test_slice.py
@@ -7,14 +7,17 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo(inp: bytes <= 10) -> bytes <= 2:
     return slice(inp, start=2, len=3)
     """,
     """
+@public
 def foo(inp: num) -> bytes <= 3:
     return slice(inp, start=2, len=3)
     """,
     """
+@public
 def foo(inp: bytes <= 10) -> bytes <= 3:
     return slice(inp, start=4.0, len=3)
     """
@@ -30,14 +33,17 @@ def test_slice_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo(inp: bytes <= 10) -> bytes <= 3:
     return slice(inp, start=2, len=3)
     """,
     """
+@public
 def foo(inp: bytes <= 10) -> bytes <= 4:
     return slice(inp, start=2, len=3)
     """,
     """
+@public
 def foo() -> bytes <= 10:
     return slice("badmintonzzz", start=1, len=10)
     """

--- a/tests/parser/syntax/test_timestamp_timedelta.py
+++ b/tests/parser/syntax/test_timestamp_timedelta.py
@@ -7,44 +7,54 @@ from viper.exceptions import TypeMismatchException
 
 fail_list = [
     """
+@public
 def foo(x: timestamp) -> num:
     return x
     """,
     """
+@public
 def foo(x: timestamp) -> timedelta:
     return x
     """,
     """
+@public
 def foo(x: timestamp, y: timedelta) -> bool:
     return y < x
     """,
     """
+@public
 def foo(x: timestamp, y: timedelta) -> timedelta:
     return x + y
     """,
     """
+@public
 def foo(x: timestamp, y: timestamp) -> timestamp:
     return x + y
     """,
     """
+@public
 def foo(x: timestamp) -> timestamp:
     return x * 2
     """,
     """
+@public
 def foo(x: timedelta, y: timedelta) -> timedelta:
     return x * y
     """,
     """
+@public
 def foo() -> timestamp:
     x = 30
     y: timestamp
     return x + y
     """,
     """
+@public
 def foo(x: timedelta, y: num (wei/sec)) -> num:
     return x * y
     """,
     """
+@public
 def foo(x: timestamp, y: num (wei/sec)) -> wei_value:
     return x * y
     """
@@ -59,91 +69,111 @@ def test_timestamp_fail(bad_code):
 
 valid_list = [
     """
+@public
 def foo(x: timestamp) -> timestamp:
     return x + 50
     """,
     """
+@public
 def foo() -> timestamp:
     return 720
     """,
     """
+@public
 def foo() -> timedelta:
     return 720
     """,
     """
+@public
 def foo(x: timestamp, y: timedelta) -> timestamp:
     return x + y
     """,
 
     """
+@public
 def foo(x: timestamp, y: timestamp) -> bool:
     return y > x
     """,
     """
+@public
 def foo(x: timedelta, y: timedelta) -> bool:
     return y == x
     """,
     """
+@public
 def foo(x: timestamp) -> timestamp:
     return x
     """,
     """
+@public
 @constant
 def foo(x: timestamp) -> num:
     return 5
     """,
     """
+@public
 @constant
 def foo(x: timestamp) -> timestamp:
     return x
     """,
     """
+@public
 def foo(x: timestamp) -> timestamp:
     y = x
     return y
     """,
     """
+@public
 def foo(x: timedelta) -> bool:
     return x > 50
     """,
     """
+@public
 def foo(x: timestamp) -> bool:
     return x > 12894712
     """,
     """
+@public
 def foo() -> timestamp:
     x: timestamp
     x = 30
     return x
     """,
     """
+@public
 def foo(x: timestamp, y: timestamp) -> timedelta:
     return x - y
     """,
     """
+@public
 def foo(x: timedelta, y: timedelta) -> timedelta:
     return x + y
     """,
     """
+@public
 def foo(x: timedelta) -> timedelta:
     return x * 2
     """,
     """
+@public
 def foo(x: timedelta, y: num (wei/sec)) -> wei_value:
     return x * y
     """,
     """
+@public
 def foo(x: num(sec, positional)) -> timestamp:
     return x
     """,
     """
 x: timedelta
+@public
 def foo() -> num(sec):
     return self.x
     """,
     """
 x: timedelta
 y: num
+@public
 @constant
 def foo() -> num(sec):
     return self.x
@@ -151,6 +181,7 @@ def foo() -> num(sec):
     """
 x: timedelta
 y: num
+@public
 def foo() -> num(sec):
     self.y = 9
     return 5

--- a/tests/parser/types/numbers/test_decimals.py
+++ b/tests/parser/types/numbers/test_decimals.py
@@ -5,46 +5,60 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_decimal_test():
     decimal_test = """
+@public
 def foo() -> num:
     return(floor(999.0))
 
+@public
 def fop() -> num:
     return(floor(333.0 + 666.0))
 
+@public
 def foq() -> num:
     return(floor(1332.1 - 333.1))
 
+@public
 def bar() -> num:
     return(floor(27.0 * 37.0))
 
+@public
 def baz() -> num:
     x = 27.0
     return(floor(x * 37.0))
 
+@public
 def baffle() -> num:
     return(floor(27.0 * 37))
 
+@public
 def mok() -> num:
     return(floor(999999.0 / 7.0 / 11.0 / 13.0))
 
+@public
 def mol() -> num:
     return(floor(499.5 / 0.5))
 
+@public
 def mom() -> num:
     return(floor(1498.5 / 1.5))
 
+@public
 def mon() -> num:
     return(floor(2997.0 / 3))
 
+@public
 def moo() -> num:
     return(floor(2997 / 3.0))
 
+@public
 def foom() -> num:
     return(floor(1999.0 % 1000.0))
 
+@public
 def foon() -> num:
     return(floor(1999.0 % 1000))
 
+@public
 def foop() -> num:
     return(floor(1999 % 1000.0))
     """
@@ -73,25 +87,30 @@ def foop() -> num:
 
 def test_harder_decimal_test():
     harder_decimal_test = """
+@public
 def phooey(inp: decimal) -> decimal:
     x = 10000.0
     for i in range(4):
         x = x * inp
     return x
 
+@public
 def arg(inp: decimal) -> decimal:
     return inp
 
+@public
 def garg() -> decimal:
     x = 4.5
     x *= 1.5
     return x
 
+@public
 def harg() -> decimal:
     x = 4.5
     x *= 2
     return x
 
+@public
 def iarg() -> wei_value:
     x = as_wei_value(7, wei)
     x *= 2

--- a/tests/parser/types/numbers/test_num.py
+++ b/tests/parser/types/numbers/test_num.py
@@ -17,10 +17,13 @@ def _num_exp(x: num, y: num) -> num:
     assert c._num_exp(3,3) == 27
     assert c._num_exp(72,19) == 72**19
 
-def test_nagative_nums(assert_tx_failed):
+def test_negative_nums(assert_tx_failed):
     negative_nums_code = """
+@public
 def _negative_num() -> num:
     return -1
+
+@public
 def _negative_exp() -> num:
     return -(1+2)
     """
@@ -32,21 +35,27 @@ def _negative_exp() -> num:
 
 def test_num_bound(assert_tx_failed):
     num_bound_code = """
+@public
 def _num(x: num) -> num:
     return x
 
+@public
 def _num_add(x: num, y: num) -> num:
     return x + y
 
+@public
 def _num_sub(x: num, y: num) -> num:
     return x - y
 
+@public
 def _num_add3(x: num, y: num, z: num) -> num:
     return x + y + z
 
+@public
 def _num_max() -> num:
     return  170141183460469231731687303715884105727   #  2**127 - 1
 
+@public
 def _num_min() -> num:
     return -170141183460469231731687303715884105728   # -2**127
     """

--- a/tests/parser/types/numbers/test_num.py
+++ b/tests/parser/types/numbers/test_num.py
@@ -4,6 +4,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_exponents_with_nums():
     exp_code = """
+@public
 def _num_exp(x: num, y: num) -> num:
     return x**y
     """

--- a/tests/parser/types/numbers/test_num256.py
+++ b/tests/parser/types/numbers/test_num256.py
@@ -6,27 +6,35 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_num256_code(assert_tx_failed):
     num256_code = """
+@public
 def _num256_add(x: num256, y: num256) -> num256:
     return num256_add(x, y)
 
+@public
 def _num256_sub(x: num256, y: num256) -> num256:
     return num256_sub(x, y)
 
+@public
 def _num256_mul(x: num256, y: num256) -> num256:
     return num256_mul(x, y)
 
+@public
 def _num256_div(x: num256, y: num256) -> num256:
     return num256_div(x, y)
 
+@public
 def _num256_gt(x: num256, y: num256) -> bool:
     return num256_gt(x, y)
 
+@public
 def _num256_ge(x: num256, y: num256) -> bool:
     return num256_ge(x, y)
 
+@public
 def _num256_lt(x: num256, y: num256) -> bool:
     return num256_lt(x, y)
 
+@public
 def _num256_le(x: num256, y: num256) -> bool:
     return num256_le(x, y)
     """
@@ -69,12 +77,15 @@ def _num256_le(x: num256, y: num256) -> bool:
 
 def test_num256_mod(assert_tx_failed):
     num256_code = """
+@public
 def _num256_mod(x: num256, y: num256) -> num256:
     return num256_mod(x, y)
 
+@public
 def _num256_addmod(x: num256, y: num256, z: num256) -> num256:
     return num256_addmod(x, y, z)
 
+@public
 def _num256_mulmod(x: num256, y: num256, z: num256) -> num256:
     return num256_mulmod(x, y, z)
     """
@@ -96,6 +107,7 @@ def _num256_mulmod(x: num256, y: num256, z: num256) -> num256:
 
 def test_num256_with_exponents(assert_tx_failed):
     exp_code = """
+@public
 def _num256_exp(x: num256, y: num256) -> num256:
         return num256_exp(x,y)
     """
@@ -113,12 +125,15 @@ def _num256_exp(x: num256, y: num256) -> num256:
 
 def test_num256_to_num_casting(assert_tx_failed):
     code = """
+@public
 def _num256_to_num(x: num(num256)) -> num:
     return x
 
+@public
 def _num256_to_num_call(x: num256) -> num:
     return self._num256_to_num(x)
 
+@public
 def built_in_conversion(x: num256) -> num:
     return as_num128(x)
     """
@@ -145,6 +160,7 @@ def built_in_conversion(x: num256) -> num:
 
 def test_modmul():
     modexper = """
+@public
 def exp(base: num256, exponent: num256, modulus: num256) -> num256:
       o = as_num256(1)
       for i in range(256):

--- a/tests/parser/types/test_bytes.py
+++ b/tests/parser/types/test_bytes.py
@@ -5,6 +5,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_test_bytes():
     test_bytes = """
+@public
 def foo(x: bytes <= 100) -> bytes <= 100:
     return x
     """
@@ -30,6 +31,7 @@ def foo(x: bytes <= 100) -> bytes <= 100:
 
 def test_test_bytes2():
     test_bytes2 = """
+@public
 def foo(x: bytes <= 100) -> bytes <= 100:
     y = x
     return y
@@ -51,24 +53,30 @@ x: num
 maa: bytes <= 60
 y: num
 
+@public
 def __init__():
     self.x = 27
     self.y = 37
 
+@public
 def set_maa(inp: bytes <= 60):
     self.maa = inp
 
+@public
 def set_maa2(inp: bytes <= 60):
     ay = inp
     self.maa = ay
 
+@public
 def get_maa() -> bytes <= 60:
     return self.maa
 
+@public
 def get_maa2() -> bytes <= 60:
     ay = self.maa
     return ay
 
+@public
 def get_xy() -> num:
     return self.x * self.y
     """
@@ -93,11 +101,13 @@ def get_xy() -> num:
 def test_test_bytes4():
     test_bytes4 = """
 a: bytes <= 60
+@public
 def foo(inp: bytes <= 60) -> bytes <= 60:
     self.a = inp
     self.a = None
     return self.a
 
+@public
 def bar(inp: bytes <= 60) -> bytes <= 60:
     b = inp
     b = None
@@ -115,23 +125,29 @@ def test_test_bytes5():
     test_bytes5 = """
 g: {a: bytes <= 50, b: bytes <= 50}
 
+@public
 def foo(inp1: bytes <= 40, inp2: bytes <= 45):
     self.g = {a: inp1, b: inp2}
 
+@public
 def check1() -> bytes <= 50:
     return self.g.a
 
+@public
 def check2() -> bytes <= 50:
     return self.g.b
 
+@public
 def bar(inp1: bytes <= 40, inp2: bytes <= 45) -> bytes <= 50:
     h = {a: inp1, b: inp2}
     return h.a
 
+@public
 def bat(inp1: bytes <= 40, inp2: bytes <= 45) -> bytes <= 50:
     h = {a: inp1, b: inp2}
     return h.b
 
+@public
 def quz(inp1: bytes <= 40, inp2: bytes <= 45):
     h = {a: inp1, b: inp2}
     self.g = h
@@ -152,6 +168,7 @@ def quz(inp1: bytes <= 40, inp2: bytes <= 45):
 
 def test_bytes_to_num_code():
     bytes_to_num_code = """
+@public
 def foo(x: bytes <= 32) -> num:
     return bytes_to_num(x)
     """

--- a/tests/parser/types/test_lists.py
+++ b/tests/parser/types/test_lists.py
@@ -9,25 +9,31 @@ z: num[3]
 z2: num[2][2]
 z3: num[2]
 
+@public
 def foo(x: num[3]) -> num:
     return x[0] + x[1] + x[2]
 
+@public
 def goo(x: num[2][2]) -> num:
     return x[0][0] + x[0][1] + x[1][0] * 10 + x[1][1] * 10
 
+@public
 def hoo(x: num[3]) -> num:
     y = x
     return y[0] + x[1] + y[2]
 
+@public
 def joo(x: num[2][2]) -> num:
     y = x
     y2 = x[1]
     return y[0][0] + y[0][1] + y2[0] * 10 + y2[1] * 10
 
+@public
 def koo(x: num[3]) -> num:
     self.z = x
     return self.z[0] + x[1] + self.z[2]
 
+@public
 def loo(x: num[2][2]) -> num:
     self.z2 = x
     self.z3 = x[1]
@@ -48,42 +54,53 @@ def test_list_output_tester_code():
     list_output_tester_code = """
 z: num[2]
 
+@public
 def foo() -> num[2]:
     return [3, 5]
 
+@public
 def goo() -> num[2]:
     x = [3, 5]
     return x
 
+@public
 def hoo() -> num[2]:
     self.z = [3, 5]
     return self.z
 
+@public
 def joo() -> num[2]:
     self.z = [3, 5]
     x = self.z
     return x
 
+@public
 def koo() -> num[2][2]:
     return [[1,2],[3,4]]
 
+@public
 def loo() -> num[2][2]:
     x = [[1,2],[3,4]]
     return x
 
+@public
 def moo() -> num[2][2]:
     x = [1,2]
     return [x,[3,4]]
 
+@public
 def noo(inp: num[2]) -> num[2]:
     return inp
 
+@public
 def poo(inp: num[2][2]) -> num[2][2]:
     return inp
 
+@public
 def qoo(inp: num[2]) -> num[2][2]:
     return [inp,[3,4]]
 
+@public
 def roo(inp: num[2]) -> decimal[2][2]:
     return [inp,[3,4]]
     """
@@ -106,6 +123,7 @@ def roo(inp: num[2]) -> decimal[2][2]:
 
 def test_array_accessor():
     array_accessor = """
+@public
 def test_array(x: num, y: num, z: num, w: num) -> num:
     a: num[4]
     a[0] = x
@@ -122,6 +140,7 @@ def test_array(x: num, y: num, z: num, w: num) -> num:
 
 def test_two_d_array_accessor():
     two_d_array_accessor = """
+@public
 def test_array(x: num, y: num, z: num, w: num) -> num:
     a: num[2][2]
     a[0][0] = x

--- a/tests/parser/types/test_string_literal.py
+++ b/tests/parser/types/test_string_literal.py
@@ -5,21 +5,27 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_string_literal_code():
     string_literal_code = """
+@public
 def foo() -> bytes <= 5:
     return "horse"
 
+@public
 def bar() -> bytes <= 10:
     return concat("b", "a", "d", "m", "i", "", "nton")
 
+@public
 def baz() -> bytes <= 40:
     return concat("0123456789012345678901234567890", "12")
 
+@public
 def baz2() -> bytes <= 40:
     return concat("01234567890123456789012345678901", "12")
 
+@public
 def baz3() -> bytes <= 40:
     return concat("0123456789012345678901234567890", "1")
 
+@public
 def baz4() -> bytes <= 100:
     return concat("01234567890123456789012345678901234567890123456789",
                   "01234567890123456789012345678901234567890123456789")
@@ -41,6 +47,7 @@ def test_string_literal_splicing_fuzz():
         kode = """
 moo: bytes <= 100
 
+@public
 def foo(s: num, L: num) -> bytes <= 100:
         x = 27
         r = slice("%s", start=s, len=L)
@@ -48,6 +55,7 @@ def foo(s: num, L: num) -> bytes <= 100:
         if x * y == 999:
             return r
 
+@public
 def bar(s: num, L: num) -> bytes <= 100:
         self.moo = "%s"
         x = 27
@@ -56,6 +64,7 @@ def bar(s: num, L: num) -> bytes <= 100:
         if x * y == 999:
             return r
 
+@public
 def baz(s: num, L: num) -> bytes <= 100:
         x = 27
         self.moo = slice("%s", start=s, len=L)

--- a/tests/parser/types/value/test_wei.py
+++ b/tests/parser/types/value/test_wei.py
@@ -5,18 +5,23 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 
 def test_test_wei():
     test_wei = """
+@public
 def return_2_finney() -> wei_value:
     return as_wei_value(2, finney)
 
+@public
 def return_3_finney() -> wei_value:
     return as_wei_value(2 + 1, finney)
 
+@public
 def return_2p5_ether() -> wei_value:
     return as_wei_value(2.5, ether)
 
+@public
 def return_3p5_ether() -> wei_value:
     return as_wei_value(2.5 + 1, ether)
 
+@public
 def return_2pow64_wei() -> wei_value:
     return as_wei_value(18446744.073709551616, szabo)
     """

--- a/viper/function_signature.py
+++ b/viper/function_signature.py
@@ -70,7 +70,7 @@ class FunctionSignature():
                 pos += get_size_of_type(parsed_type) * 32
 
         # Apply decorators
-        const, payable, internal = False, False, False
+        const, payable, internal, public = False, False, False, False
         for dec in code.decorator_list:
             if isinstance(dec, ast.Name) and dec.id == "constant":
                 const = True
@@ -78,8 +78,15 @@ class FunctionSignature():
                 payable = True
             elif isinstance(dec, ast.Name) and dec.id == "internal":
                 internal = True
+            elif isinstance(dec, ast.Name) and dec.id == "public":
+                public = True
             else:
                 raise StructureException("Bad decorator", dec)
+        if public and internal:
+            raise StructureException("Cannot use public and internal decorators on the same function")
+        if not public and not internal and not isinstance(code.body[0], ast.Pass):
+            # import pdb; pdb.set_trace()
+            raise StructureException("Function visibility must be declared")
         # Determine the return type and whether or not it's constant. Expects something
         # of the form:
         # def foo(): ...

--- a/viper/function_signature.py
+++ b/viper/function_signature.py
@@ -85,7 +85,6 @@ class FunctionSignature():
         if public and internal:
             raise StructureException("Cannot use public and internal decorators on the same function")
         if not public and not internal and not isinstance(code.body[0], ast.Pass):
-            # import pdb; pdb.set_trace()
             raise StructureException("Function visibility must be declared")
         # Determine the return type and whether or not it's constant. Expects something
         # of the form:

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -155,7 +155,7 @@ def _mk_getter_helper(typ, depth=0):
 # Make a list of getters for a given variable name with a given type
 def mk_getter(varname, typ):
     funs = _mk_getter_helper(typ)
-    return ['@constant\ndef get_%s%s(%s) -> %s: return self.%s%s' % (varname, funname, head.rstrip(', '), base, varname, tail)
+    return ['@public\n@constant\ndef get_%s%s(%s) -> %s: return self.%s%s' % (varname, funname, head.rstrip(', '), base, varname, tail)
             for (funname, head, tail, base) in funs]
 
 

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -155,7 +155,7 @@ def _mk_getter_helper(typ, depth=0):
 # Make a list of getters for a given variable name with a given type
 def mk_getter(varname, typ):
     funs = _mk_getter_helper(typ)
-    return ['@public\n@constant\ndef get_%s%s(%s) -> %s: return self.%s%s' % (varname, funname, head.rstrip(', '), base, varname, tail)
+    return ["""@public\n@constant\ndef get_%s%s(%s) -> %s: return self.%s%s""" % (varname, funname, head.rstrip(', '), base, varname, tail)
             for (funname, head, tail, base) in funs]
 
 


### PR DESCRIPTION
### - Motivation
 Vitalik in recent Gitter convo -> "(imo mandating having one or the other is the right way to do it; there's so much of an established culture of "functions are public by default" that simply switching the default to private for functions would lead to even more confusion and bugs)"
@jacqueswww and I agree
Also covers #407

### - What I did
Require all function declarations to have either an `@public` or `@internal` decorator.

### - How I did it
Added a check for public decorators in `function_signature.py`.
Changed all functions that relied on the old default public visibility and declared them explicitly public

### - How to verify it
Look at the changes I made to `function_signature.py`.
I had to make changes to almost all function declarations in Viper, but not tests were added / lost.

### - Description for the changelog
Require function visibility to be declared
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/32795438-dfc3743a-c928-11e7-957c-eef43761480a.png)

