### PR TITLE
Add checks preventing assigning values on defining types.

### DIFF
--- a/tests/parser/exceptions/test_structure_exception.py
+++ b/tests/parser/exceptions/test_structure_exception.py
@@ -131,6 +131,16 @@ def foo():
     """
 def foo():
     x = y = 3
+    """,
+    """
+def foo() -> num:
+    q:num = 111
+    return q
+    """,
+    """
+q:num = 111
+def foo() -> num:
+    return self.q
     """
 ]
 

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -171,7 +171,9 @@ def add_contract(code):
 
 
 def add_globals_and_events(_defs, _events, _getters, _globals, item):
-    if isinstance(item.annotation, ast.Call) and item.annotation.func.id == "__log__":
+    if item.value is not None:
+        raise StructureException('May not assign value whilst defining type', item)
+    elif isinstance(item.annotation, ast.Call) and item.annotation.func.id == "__log__":
         if _globals or len(_defs):
             raise StructureException("Events must all come before global declarations and function definitions", item)
         _events.append(item)

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -69,6 +69,8 @@ class Stmt(object):
         return LLLnode.from_list('pass', typ=None, pos=getpos(self.stmt))
 
     def ann_assign(self):
+        if self.stmt.value is not None:
+            raise StructureException('May not assign value whilst defining type', self.stmt)
         typ = parse_type(self.stmt.annotation, location='memory')
         varname = self.stmt.target.id
         pos = self.context.new_variable(varname, typ)


### PR DESCRIPTION
### - What I did

Fixes #410 adds tests.

### - How I did it

Figured out it has to do with `.value` attribute on annotate assign.

### - How to verify it
The following will fail to compile now:
```python
def foo() -> num:
    q:num = 111
    return q
```

### - Description for the changelog
Fixes ambiguous assign on annotate syntax.

### - Cute Animal Picture
![](http://2.bp.blogspot.com/-OKpIGxH_grs/TV7UnDKDzhI/AAAAAAAAEHI/K7j2oMw1TNE/s1600/90720417.jpg)

