### PR TITLE
Add public decorator to tests

### DIFF
--- a/tests/parser/features/iteration/test_range_in.py
+++ b/tests/parser/features/iteration/test_range_in.py
@@ -82,13 +82,16 @@ def test_ownership(assert_tx_failed):
 
 owners: address[2]
 
+@public
 def __init__():
     self.owners[0] = msg.sender
 
+@public
 def set_owner(i: num, new_owner: address):
     assert msg.sender in self.owners
     self.owners[i] = new_owner
 
+@public
 def is_owner() -> bool:
     return msg.sender in self.owners
     """


### PR DESCRIPTION
### - What I did
Added `@public` to three tests that didn't have it.

### - How I did it
Found three tests without the `@public` decorator that should have it.
### - How to verify it
Look at my PR
### - Description for the changelog
None
