### PR TITLE
function visibility doc and error message updates

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Following the principles and goals, Viper **does not** provide the following fea
 Compatibility-breaking Changelog
 ********************************
 
+* **2017.11.15**: Functions require either ``@internal`` or ``@public`` decorators.
 * **2017.07.25**: The ``def foo() -> num(const): ...`` syntax no longer works; you now need to do ``def foo() -> num: ...`` with a ``@constant`` decorator on the previous line.
 * **2017.07.25**: Functions without a ``@payable`` decorator now fail when called with nonzero wei.
 * **2017.07.25**: A function can only call functions that are declared above it (that is, A can call B only if B appears earlier in the code than A does). This was introduced 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -33,12 +33,13 @@ Functions are the executable units of code within a contract.
 
 ::
 
+  @public
   @payable
-  function bid(): // Function
+  def bid(): // Function
     // ...
   }
 
 :ref:`function-calls` can happen internally or externally
 and have different levels of visibility (:ref:`visibility-and-getters`)
-towards other contracts.
+towards other contracts. Functions must be decorated with either @public or @internal.
 

--- a/viper/function_signature.py
+++ b/viper/function_signature.py
@@ -85,7 +85,7 @@ class FunctionSignature():
         if public and internal:
             raise StructureException("Cannot use public and internal decorators on the same function")
         if not public and not internal and not isinstance(code.body[0], ast.Pass):
-            raise StructureException("Function visibility must be declared")
+            raise StructureException("Function visibility must be declared (@public or @internal)")
         # Determine the return type and whether or not it's constant. Expects something
         # of the form:
         # def foo(): ...


### PR DESCRIPTION
### - What I did
Made the example in "Structure of a Contract / Functions" correct.
Clarified the error message when visibility declaration is missing.
### - How I did it
Added `@public` to the example in the Structure of a Contract / Functions.
Changed `function` to `def` in that example (that's correct right?)
Added a hint to the error message that it expects `@public` or `@internal`
### - How to verify it

### - Description for the changelog
Documentation and error message updates
### - Cute Animal Picture


![](http://www.barricks.com/great_animal_pictures010.jpg)