### PR TITLE
Add the install instructions for the Viper snap

### DIFF
--- a/docs/installing-viper.rst
+++ b/docs/installing-viper.rst
@@ -131,3 +131,14 @@ and try compiling a contract:
 ::
     make test
     viper examples/crowdfund.v.py
+
+****
+Snap
+****
+
+Viper is published in the snap store. In any of the `supported Linux distros <https://snapcraft.io/docs/core/install>`_, install it with:
+::
+    sudo snap install viper --edge
+
+
+(Note that this is an experimental and unstable release, at the moment)


### PR DESCRIPTION
This requiries #445, and enabling the continuous delivery on https://build.snapcraft.io

### - What I did

Added instructions to install the viper snap

### - How I did it

I fought a little with rst syntax :)

### - How to verify it

After #445 lands and the snap is published to the edge channel in the store, run the documented command.

### - Description for the changelog

Add the install instructions for the Viper snap

### - Cute Animal Picture

![photo4949638119024601010](https://user-images.githubusercontent.com/617831/33139713-bc6e2416-cf73-11e7-8404-d8114ba5a9d3.jpg)

(I only have one cute animal, sorry)
