### PR TITLE
Use revert opcode for assert statements

### DIFF
--- a/tests/parser/features/test_assert.py
+++ b/tests/parser/features/test_assert.py
@@ -1,0 +1,18 @@
+import pytest
+from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
+    get_contract_with_gas_estimation, get_contract
+
+def test_assert_refund(t):
+    code = """
+@public
+def foo():
+    assert 1 == 2
+"""
+    c = get_contract_with_gas_estimation(code)
+    pre_balance = t.s.head_state.get_balance(t.a0)
+    with pytest.raises(t.TransactionFailed):
+        c.foo(startgas=10**6, gasprice=10)
+    post_balance = t.s.head_state.get_balance(t.a0)
+    # Checks for gas refund from revert
+    # 10**5 is added to account for gas used before the transactions fails
+    assert pre_balance < post_balance + 10**5

--- a/viper/compile_lll.py
+++ b/viper/compile_lll.py
@@ -155,7 +155,10 @@ def compile_to_assembly(code, withargs=None, break_dest=None, height=0):
     # Assert (if false, exit)
     elif code.value == 'assert':
         o = compile_to_assembly(code.args[0], withargs, break_dest, height)
-        o.extend(['ISZERO', 'PC', 'JUMPI'])
+        end_symbol = mksymbol()
+        o.extend([end_symbol, 'JUMPI'])
+        o.extend(['PUSH1', 0, 'DUP1', 'REVERT'])
+        o.extend([end_symbol, 'JUMPDEST'])
         return o
     # Unsigned/signed clamp, check less-than
     elif code.value in ('uclamplt', 'uclample', 'clamplt', 'clample', 'uclampgt', 'uclampge', 'clampgt', 'clampge'):
@@ -173,21 +176,22 @@ def compile_to_assembly(code, withargs=None, break_dest=None, height=0):
         o.extend(['DUP2'])
         # Stack: num num bound
         if code.value == 'uclamplt':
-            o.extend(["LT", 'ISZERO', 'PC', 'JUMPI'])
+            o.extend(["LT", 'ISZERO'])
         elif code.value == "clamplt":
-            o.extend(["SLT", 'ISZERO', 'PC', 'JUMPI'])
+            o.extend(["SLT", 'ISZERO'])
         elif code.value == "uclample":
-            o.extend(["GT", 'PC', 'JUMPI'])
+            o.extend(["GT"])
         elif code.value == "clample":
-            o.extend(["SGT", 'PC', 'JUMPI'])
+            o.extend(["SGT"])
         elif code.value == 'uclampgt':
-            o.extend(["GT", 'ISZERO', 'PC', 'JUMPI'])
+            o.extend(["GT", 'ISZERO'])
         elif code.value == "clampgt":
-            o.extend(["SGT", 'ISZERO', 'PC', 'JUMPI'])
+            o.extend(["SGT", 'ISZERO'])
         elif code.value == "uclampge":
-            o.extend(["LT", 'PC', 'JUMPI'])
+            o.extend(["LT"])
         elif code.value == "clampge":
-            o.extend(["SLT", 'PC', 'JUMPI'])
+            o.extend(["SLT"])
+        o.extend(['PC', 'JUMPI'])
         return o
     # Signed clamp, check against upper and lower bounds
     elif code.value in ('clamp', 'uclamp'):

--- a/viper/opcodes.py
+++ b/viper/opcodes.py
@@ -65,10 +65,11 @@ opcodes = {
     'RETURN': [0xf3, 2, 0, 0],
     'DELEGATECALL': [0xf4, 6, 1, 700],
     'CALLBLACKBOX': [0xf5, 7, 1, 700],
-    'INVALID': [0xfe, 0, 0, 0],
-    'SUICIDE': [0xff, 1, 0, 5000],
     'SELFDESTRUCT': [0xff, 1, 0, 25000],
     'STATICCALL': [0xfa, 6, 1, 40],
+    'REVERT': [0xfd, 2, 0, 0],
+    'SUICIDE': [0xff, 1, 0, 5000],
+    'INVALID': [0xfe, 0, 0, 0],
 }
 
 pseudo_opcodes = {


### PR DESCRIPTION
### - What I did
Assert now uses the `revert` opcode behind the scenes so gas is refunded when it's used. 
This PR is in response to VIP #478 
### - How I did it
I added in the revert opcode and changed `assert` in `compile_lll.py` to use `REVERT` instead of `PC, JUMPI`.
### - How to verify it
Look at `test_assert.py` to verify that unused gas is actually being refunded.
### - Description for the changelog
Modify assert to use revert opcode
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/33152094-1854010a-cf98-11e7-9b27-6e575aad5d4e.png)
