### PR TITLE
types.py: Remove duplicated method

### DIFF
--- a/viper/types.py
+++ b/viper/types.py
@@ -4,6 +4,7 @@ import copy
 from .exceptions import InvalidTypeException
 from .utils import (
     base_types,
+    ceil32,
     is_varname_valid,
     valid_units,
 )
@@ -309,11 +310,6 @@ def parse_type(item, location):
         return TupleType(members)
     else:
         raise InvalidTypeException("Invalid type: %r" % ast.dump(item), item)
-
-
-# Rounds up to nearest 32, eg. 95 -> 96, 96 -> 96, 97 -> 128
-def ceil32(x):
-    return x + 31 - (x - 1) % 32
 
 
 # Gets the number of memory or storage keys needed to represent a given type


### PR DESCRIPTION
Fix https://github.com/ethereum/viper/issues/488

### - What I did

Remove duplication of `ceil32()` method.

### - How I did it

Remove the definition in `types.py` and import `utils.ceil32` there.

### - How to verify it

```sh
$ git grep "def ceil32"
viper/utils.py:def ceil32(x):
```

### - Cute Animal Picture

![I wonder if someone already post duplicated pic](https://cdn.pixabay.com/photo/2016/11/15/12/36/cat-1826119_960_720.jpg)
