### PR TITLE
Adds -f bytecode_runtime support.

### DIFF
--- a/bin/viper
+++ b/bin/viper
@@ -11,7 +11,7 @@ from viper.parser import parser_utils
 
 parser = argparse.ArgumentParser(description='Viper {0} programming language for Ethereum'.format(viper.__version__))
 parser.add_argument('input_file', help='Viper sourcecode to compile')
-parser.add_argument('-f', help='Format to print', choices=['abi', 'json', 'bytecode', 'ir'], default='bytecode', dest='format')
+parser.add_argument('-f', help='Format to print', choices=['abi', 'json', 'bytecode', 'bytecode_runtime', 'ir'], default='bytecode', dest='format')
 parser.add_argument('--show-gas-estimates', help='Show gas estimates in ir output mode.', action="store_true")
 
 args = parser.parse_args()
@@ -29,5 +29,7 @@ if __name__ == '__main__':
             print(json.dumps(compiler.mk_full_signature(code)))
         elif args.format == 'bytecode':
             print('0x' + compiler.compile(code).hex())
+        elif args.format == 'bytecode_runtime':
+            print('0x' + compiler.compile(code, bytecode_runtime=True).hex())
         elif args.format == 'ir':
             print(optimizer.optimize(parse_to_lll(code)))

--- a/tests/compiler/test_bytecode_runtime.py
+++ b/tests/compiler/test_bytecode_runtime.py
@@ -1,0 +1,15 @@
+from viper import compiler
+
+
+def test_bytecode_runtime():
+    code = """
+@public
+def a() -> bool:
+    return true
+    """
+
+    bytecode = compiler.compile(code)
+    bytecode_runtime = compiler.compile(code, bytecode_runtime=True)
+
+    assert len(bytecode) > len(bytecode_runtime)
+    assert bytecode_runtime in bytecode

--- a/viper/compiler.py
+++ b/viper/compiler.py
@@ -8,7 +8,7 @@ def memsize_to_gas(memsize):
 
 
 def compile(code, *args, **kwargs):
-    lll = optimizer.optimize(parser.parse_tree_to_lll(parser.parse(code), code))
+    lll = optimizer.optimize(parser.parse_tree_to_lll(parser.parse(code), code, runtime_only=kwargs.get('bytecode_runtime', False)))
     return compile_lll.assembly_to_evm(compile_lll.compile_to_assembly(lll))
 
 


### PR DESCRIPTION
### - What I did

Adds -f bytecode_runtime support. For populus integration the runtime bytecode is required, this adds a format to the viper binary. The solc equivalent would be: `--bin-runtime`.
### - How I did it

Came up for the populus integration. Traced the lll output from -f ir.

### - How to verify it

Hmm not sure, place a debugger in `def compile` and check the lll value.

### - Description for the changelog
Adds support for -f bytecode_runtime.

### - Cute Animal Picture
![](https://i.pinimg.com/originals/78/72/3d/78723da0608be662bba20817e7e394c4.jpg)
