### PR TITLE
Show lineno and code on bunch of error

### DIFF
--- a/viper/function_signature.py
+++ b/viper/function_signature.py
@@ -85,7 +85,7 @@ class FunctionSignature():
         if public and internal:
             raise StructureException("Cannot use public and internal decorators on the same function")
         if not public and not internal and not isinstance(code.body[0], ast.Pass):
-            raise StructureException("Function visibility must be declared (@public or @internal)")
+            raise StructureException("Function visibility must be declared (@public or @internal)", code)
         # Determine the return type and whether or not it's constant. Expects something
         # of the form:
         # def foo(): ...

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -653,7 +653,7 @@ def pack_logging_topics(event_id, args, topics_types, context):
                 topics.append(byte_array_to_num(input, arg, 'num256', size))
         else:
             input = unwrap_location(input)
-            input = base_type_conversion(input, input.typ, typ)
+            input = base_type_conversion(input, input.typ, typ, arg)
             topics.append(input)
     return topics
 
@@ -661,7 +661,7 @@ def pack_logging_topics(event_id, args, topics_types, context):
 def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder):
     if isinstance(typ, BaseType):
         input = parse_expr(arg, context)
-        input = base_type_conversion(input, input.typ, typ)
+        input = base_type_conversion(input, input.typ, typ, arg)
         holder.append(LLLnode.from_list(['mstore', placeholder, input], typ=typ, location='memory'))
     elif isinstance(typ, ByteArrayType):
         bytez = b''


### PR DESCRIPTION
### - What I did

Make the error show the line number.

### - How I did it

By passing the ast object into the exception and conversion function.

### - How to verify it

Test code
```py
SomeLog: __log__({
	_var: num256
})

some_var: num

# Error here
def some_func(a: num):
	log.SomeLog(self.some_var) # Error here
```

Stack trace
```
viper.exceptions.StructureException: line 8: Function visibility must be declared (@public or @internal)
def some_func(a: num):
```

```
viper.exceptions.TypeMismatchException: line 9: Typecasting from base type num to num256 unavailable
        log.SomeLog(self.some_var)
-------------^
```

