### PR TITLE
Fix modulo doesn't clamp_nonzero when divisor is decimal

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,12 @@ def get_contract_from_lll(t):
     return lll_compiler
 
 @pytest.fixture
-def assert_tx_failed():
+def assert_tx_failed(t):
     def assert_tx_failed(function_to_test, exception = tester.TransactionFailed):
-        initial_state = tester.s.snapshot()
+        initial_state = t.s.snapshot()
         with pytest.raises(exception):
             function_to_test()
-        tester.s.revert(initial_state)
+        t.s.revert(initial_state)
     return assert_tx_failed
 
 @pytest.fixture

--- a/tests/examples/auctions/test_simple_open_auction.py
+++ b/tests/examples/auctions/test_simple_open_auction.py
@@ -1,23 +1,20 @@
 import pytest
-from ethereum.tools import tester
 import ethereum.utils as utils
 
 FIVE_DAYS = 432000
 
 @pytest.fixture
-def auction_tester():
-    t = tester
-    tester.s = t.Chain()
+def auction_tester(t):
     from viper import compiler
     t.languages['viper'] = compiler.Compiler()
     contract_code = open('examples/auctions/simple_open_auction.v.py').read()
-    tester.c = tester.s.contract(contract_code, language='viper', args=[tester.accounts[0], FIVE_DAYS])
-    return tester
+    t.c = t.s.contract(contract_code, language='viper', args=[t.accounts[0], FIVE_DAYS])
+    return t
 
 
 def test_initial_state(auction_tester):
     # Check beneficiary is correct
-    assert utils.remove_0x_head(auction_tester.c.get_beneficiary()) == tester.accounts[0].hex()
+    assert utils.remove_0x_head(auction_tester.c.get_beneficiary()) == auction_tester.accounts[0].hex()
     # Check bidding time is 5 days
     assert auction_tester.c.get_auction_end() == auction_tester.s.head_state.timestamp + 432000
     # Check start time is current block timestamp
@@ -31,43 +28,45 @@ def test_initial_state(auction_tester):
 
 
 def test_bid(auction_tester, assert_tx_failed):
+    auction_tester.s.mine()
     # Bidder cannot bid 0
     assert_tx_failed(lambda: auction_tester.c.bid(value=0, sender=auction_tester.k1))
     # Bidder can bid
-    auction_tester.c.bid(value=1, sender=tester.k1)
+    auction_tester.c.bid(value=1, sender=auction_tester.k1)
     # Check that higest bidder and highest bid have changed accordingly
     assert utils.remove_0x_head(auction_tester.c.get_highest_bidder()) == auction_tester.accounts[1].hex()
     assert auction_tester.c.get_highest_bid() == 1
     # Bidder bid cannot equal current highest bid
     assert_tx_failed(lambda: auction_tester.c.bid(value=1, sender=auction_tester.k1))
     # Higher bid can replace current highest bid
-    auction_tester.c.bid(value=2, sender=tester.k2)
+    auction_tester.c.bid(value=2, sender=auction_tester.k2)
     # Check that higest bidder and highest bid have changed accordingly
     assert utils.remove_0x_head(auction_tester.c.get_highest_bidder()) == auction_tester.accounts[2].hex()
     assert auction_tester.c.get_highest_bid() == 2
     # Multiple bidders can bid
-    auction_tester.c.bid(value=3, sender=tester.k3)
-    auction_tester.c.bid(value=4, sender=tester.k4)
-    auction_tester.c.bid(value=5, sender=tester.k5)
+    auction_tester.c.bid(value=3, sender=auction_tester.k3)
+    auction_tester.c.bid(value=4, sender=auction_tester.k4)
+    auction_tester.c.bid(value=5, sender=auction_tester.k5)
     # Check that higest bidder and highest bid have changed accordingly
     assert utils.remove_0x_head(auction_tester.c.get_highest_bidder()) == auction_tester.accounts[5].hex()
     assert auction_tester.c.get_highest_bid() == 5
-    auction_tester.c.bid(value=1 * 10**10, sender=tester.k1)
+    auction_tester.c.bid(value=1 * 10**10, sender=auction_tester.k1)
     balance_before_out_bid = auction_tester.s.head_state.get_balance(auction_tester.accounts[1])
-    auction_tester.c.bid(value=2 * 10**10, sender=tester.k2)
+    auction_tester.c.bid(value=2 * 10**10, sender=auction_tester.k2)
     balance_after_out_bid = auction_tester.s.head_state.get_balance(auction_tester.accounts[1])
     # Account has more money after its bid is out bid
     assert balance_after_out_bid > balance_before_out_bid
 
 
 def test_auction_end(auction_tester, assert_tx_failed):
+    auction_tester.s.mine()
     # Fails if auction end time has not been reached
     assert_tx_failed(lambda: auction_tester.c.auction_end())
-    auction_tester.c.bid(value=1 * 10**10, sender=tester.k2)
+    auction_tester.c.bid(value=1 * 10**10, sender=auction_tester.k2)
     # Move block timestamp foreward to reach auction end time
     auction_tester.s.head_state.timestamp += FIVE_DAYS
     balance_before_end = auction_tester.s.head_state.get_balance(auction_tester.accounts[0])
-    auction_tester.c.auction_end(sender=tester.k2)
+    auction_tester.c.auction_end(sender=auction_tester.k2)
     balance_after_end = auction_tester.s.head_state.get_balance(auction_tester.accounts[0])
     # Beneficiary receives the highest bid
     assert balance_after_end == balance_before_end + 1 * 10 ** 10

--- a/tests/parser/features/arithmetic/test_modulo.py
+++ b/tests/parser/features/arithmetic/test_modulo.py
@@ -1,0 +1,58 @@
+import pytest
+from viper.exceptions import TypeMismatchException
+from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
+    get_contract_with_gas_estimation, get_contract
+
+
+def test_modulo():
+    code = """
+@public
+def num_modulo_num() -> num:
+    return 1 % 2
+
+@public
+def decimal_modulo_decimal() -> decimal:
+    return 1.5 % .33
+
+@public
+def decimal_modulo_num() -> decimal:
+    return .5 % 1
+
+
+@public
+def num_modulo_decimal() -> decimal:
+    return 1.5 % 1
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert c.num_modulo_num() == 1
+    assert c.decimal_modulo_decimal() == .18
+    assert c.decimal_modulo_num() == .5
+    assert c.num_modulo_decimal() == .5
+
+
+def test_modulo_with_different_units(assert_compile_failed):
+    code = """
+@public
+def foo(a: currency_value, b: num):
+    x = a % b
+"""
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), TypeMismatchException)
+
+
+def test_modulo_with_positional_input(assert_compile_failed):
+    code = """
+@public
+def foo(a: num(sec, positional), b: num):
+    x = a % b
+"""
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), TypeMismatchException)
+
+
+def test_modulo_with_input_of_zero(assert_tx_failed):
+    code = """
+@public
+def foo(a: num, b: decimal) -> decimal:
+    return a % b
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert_tx_failed(lambda: c.foo(1, 0))

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -280,7 +280,7 @@ class Expr(object):
                 o = LLLnode.from_list(['smod', left, ['mul', ['clamp_nonzero', right], DECIMAL_DIVISOR]],
                                       typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
             elif ltyp == 'num' and rtyp == 'decimal':
-                o = LLLnode.from_list(['smod', ['mul', left, DECIMAL_DIVISOR], right],
+                o = LLLnode.from_list(['smod', ['mul', left, DECIMAL_DIVISOR], ['clamp_nonzero', right]],
                                       typ=BaseType('decimal', new_unit), pos=getpos(self.expr))
         elif isinstance(self.expr.op, ast.Pow):
             if left.typ.positional or right.typ.positional:


### PR DESCRIPTION
### - What I did
Added a non zero clamp to modulo between `num%decimal`.
This PR is in response to #493 @yzhang90

### - How I did it
Created a test that should throw an error (`1 % 0`) and changed the `LLL` so that it now throws an error.

### - How to verify it
Look at the LLL and tests I added.

### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/33220410-371035aa-d105-11e7-8bd8-605981fc30d0.png)

