### PR TITLE
Use `with` to decrease gas costs

### DIFF
--- a/viper/parser/parser_utils.py
+++ b/viper/parser/parser_utils.py
@@ -255,8 +255,9 @@ def make_byte_array_copier(destination, source):
         gas_calculation = opcodes.GIDENTITYBASE + \
             opcodes.GIDENTITYWORD * (ceil32(source.typ.maxlen) // 32)
         o = LLLnode.from_list(
-            ['with', '_sz', ['add', 32, ['mload', source]],
-                ['assert', ['call', ['add', 18, ['div', '_sz', 10]], 4, 0, source, '_sz', destination, '_sz']]], typ=None, add_gas_estimate=gas_calculation)
+            ['with', '_source', source,
+                ['with', '_sz', ['add', 32, ['mload', '_source']],
+                    ['assert', ['call', ['add', 18, ['div', '_sz', 10]], 4, 0, '_source', '_sz', destination, '_sz']]]], typ=None, add_gas_estimate=gas_calculation)
         return o
 
     pos_node = LLLnode.from_list('_pos', typ=source.typ, location=source.location)


### PR DESCRIPTION
### - What I did
Use `with` statement to decrease gas costs.
### - How I did it
I saw some `LLL` on gitter that looked repetitive so I looked for where it was being created and refactored it. 
### - How to verify it
```
def foo():
    v = "abc"
```
Run the following benchmark with and without my PR and confirm the following results:
Decreases deployment by ~7,000 gas saving
Decreases function call by ~10,000 gas saving
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/33157252-ffe1cab4-cfbd-11e7-9ad5-d81453957dce.png)

