### PR TITLE
Add check to as_num256 to make sure number is greater than 0

### DIFF
--- a/tests/parser/functions/test_as_num256.py
+++ b/tests/parser/functions/test_as_num256.py
@@ -1,0 +1,21 @@
+import pytest
+from tests.setup_transaction_tests import chain as s, tester as t, ethereum_utils as u, check_gas, \
+    get_contract_with_gas_estimation, get_contract
+
+def test_as_num256_with_negative_num(assert_compile_failed):
+    code = """
+@public
+def foo() -> num256:
+    return as_num256(1-2)
+"""
+    assert_compile_failed(lambda: get_contract_with_gas_estimation(code), Exception)
+
+
+def test_as_num256_with_negative_input(assert_tx_failed):
+    code = """
+@public
+def foo(x: num) -> num256:
+    return as_num256(x)
+"""
+    c = get_contract_with_gas_estimation(code)
+    assert_tx_failed(lambda: c.foo(-1))

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -183,9 +183,9 @@ def as_num256(expr, args, kwargs, context):
     if isinstance(args[0], int):
         if not(0 <= args[0] <= 2**256 - 1):
             raise InvalidLiteralException("Number out of range: " + str(expr.args[0].n), expr.args[0])
-        return LLLnode.from_list(args[0], typ=BaseType('num256', None), pos=getpos(expr))
+        return LLLnode.from_list(args[0], typ=BaseType('num256'), pos=getpos(expr))
     elif isinstance(args[0], LLLnode):
-        return LLLnode(value=args[0].value, args=args[0].args, typ=BaseType('num256'), pos=getpos(expr))
+        return LLLnode.from_list(['clampge', args[0], 0], typ=BaseType('num256'), pos=getpos(expr))
     else:
         raise InvalidLiteralException("Invalid input for num256: %r" % args[0], expr)
 


### PR DESCRIPTION
### - What I did
Add a signed check to `as_num256` that throws if `as_num256` is called on a negative input (`num256 is unsigned).
This PR is in response to #469

### - How I did it
I created a test that called `as_num256` on a negative value and then I made it fail.
### - How to verify it
Look at the test I created.
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/33232494-9fa496fa-d1c4-11e7-89d1-fcbdd547aa40.png)

