### PR TITLE
Change vipercoin from returning false to throwing

### DIFF
--- a/examples/tokens/vipercoin.v.py
+++ b/examples/tokens/vipercoin.v.py
@@ -58,33 +58,29 @@ def totalSupply() -> num256:
 @public
 def transfer(_to: address, _amount: num(num256)) -> bool:
 
-    if self.balances[msg.sender] >= _amount and \
-       self.balances[_to] + _amount >= self.balances[_to]:
+    assert self.balances[msg.sender] >= _amount
+    assert self.balances[_to] + _amount >= self.balances[_to]
 
-        self.balances[msg.sender] -= _amount  # Subtract from the sender
-        self.balances[_to] += _amount  # Add the same to the recipient
-        log.Transfer(msg.sender, _to, as_num256(_amount))  # log transfer event.
+    self.balances[msg.sender] -= _amount  # Subtract from the sender
+    self.balances[_to] += _amount  # Add the same to the recipient
+    log.Transfer(msg.sender, _to, as_num256(_amount))  # log transfer event.
 
-        return True
-    else:
-        return False
+    return True
 
 
 # Transfer allowed tokens from a specific account to another.
 @public
 def transferFrom(_from: address, _to: address, _value: num(num256)) -> bool:
 
-    if _value <= self.allowed[_from][msg.sender] and \
-       _value <= self.balances[_from]:
+    assert _value <= self.allowed[_from][msg.sender]
+    assert _value <= self.balances[_from]
 
-        self.balances[_from] -= _value  # decrease balance of from address.
-        self.allowed[_from][msg.sender] -= _value  # decrease allowance.
-        self.balances[_to] += _value  # incease balance of to address.
-        log.Transfer(_from, _to, as_num256(_value))  # log transfer event.
-
-        return True
-    else:
-        return False
+    self.balances[_from] -= _value  # decrease balance of from address.
+    self.allowed[_from][msg.sender] -= _value  # decrease allowance.
+    self.balances[_to] += _value  # incease balance of to address.
+    log.Transfer(_from, _to, as_num256(_value))  # log transfer event.
+    
+    return True
 
 
 # Allow _spender to withdraw from your account, multiple times, up to the _value amount.

--- a/tests/examples/tokens/test_vipercoin.py
+++ b/tests/examples/tokens/test_vipercoin.py
@@ -49,10 +49,8 @@ def test_transfer(token_tester, assert_tx_failed):
     assert token_tester.c.balanceOf(token_tester.accounts[1]) == 1
     assert token_tester.c.balanceOf(token_tester.accounts[0]) == TOKEN_TOTAL_SUPPLY - 1
 
-    # Some edge cases:
-
     # more than allowed
-    assert token_tester.c.transfer(token_tester.accounts[1], TOKEN_TOTAL_SUPPLY) is False
+    assert_tx_failed(lambda: token_tester.c.transfer(token_tester.accounts[1], TOKEN_TOTAL_SUPPLY))
 
     # Negative transfer value.
     assert_tx_failed(
@@ -87,7 +85,7 @@ def test_transferFrom(token_tester, assert_tx_failed):
     assert contract.allowance(a0, a1) == ALLOWANCE - 3
 
     # a2 may not transfer.
-    assert contract.transferFrom(a0, a2, ALLOWANCE, sender=k2) is False
+    assert_tx_failed(lambda: contract.transferFrom(a0, a2, ALLOWANCE, sender=k2))
 
     # Negative transfer value.
     assert_tx_failed(
@@ -96,7 +94,7 @@ def test_transferFrom(token_tester, assert_tx_failed):
     )
 
     # Transfer more than allowance:
-    assert contract.transferFrom(a0, a2, 8, sender=k1) is False
+    assert_tx_failed(lambda: contract.transferFrom(a0, a2, 8, sender=k1))
     assert contract.balanceOf(a0) == TOKEN_TOTAL_SUPPLY - 3
     assert contract.balanceOf(a1) == 0
     assert contract.balanceOf(a2) == 3


### PR DESCRIPTION
### - What I did
Change `transfer` and `transferFrom` to throw if conditions are invalid instead of returning false.
This PR is in response to #505 
### - How I did it
Changed the `test_vipercoin.py` to expert `TransactionFailed` as opposed to `False`.
Changed `vipercoin.v.py` to pass the new test requirements.
### - How to verify it
Look at the tests/code I changed.
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/33232633-b34580dc-d1c6-11e7-84c0-0d161eb6b064.png)
