### PR TITLE
Add logging error to argument number mismatch and improve bytes support

### DIFF
--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -693,7 +693,7 @@ def pack_args_by_32(holder, maxlen, arg, typ, context, placeholder):
             if input.typ.maxlen > typ.maxlen:
                 raise TypeMismatchException("Data input bytes are to big: %r %r" % (input.typ, typ))
             if arg.id in context.vars:
-                size = context.vars[arg.id].size
+                size = input.typ.maxlen
                 holder.append(LLLnode.from_list(['mstore', placeholder, byte_array_to_num(parse_expr(arg, context), arg, 'num256', size)], typ=typ, location='memory'))
     elif isinstance(typ, ListType):
             maxlen += (typ.count - 1) * 32

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -135,6 +135,8 @@ class Stmt(object):
             if self.stmt.func.attr not in self.context.sigs['self']:
                 raise VariableDeclarationException("Event not declared yet: %s" % self.stmt.func.attr)
             event = self.context.sigs['self'][self.stmt.func.attr]
+            if len(event.indexed_list) != len(self.stmt.args):
+                raise VariableDeclarationException("%s received %s arguments but expected %s" % (event.name, len(self.stmt.args), len(event.indexed_list)))
             topics_types, topics = [], []
             data_types, data = [], []
             for pos, is_indexed in enumerate(event.indexed_list):

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -137,17 +137,17 @@ class Stmt(object):
             event = self.context.sigs['self'][self.stmt.func.attr]
             if len(event.indexed_list) != len(self.stmt.args):
                 raise VariableDeclarationException("%s received %s arguments but expected %s" % (event.name, len(self.stmt.args), len(event.indexed_list)))
-            topics_types, topics = [], []
-            data_types, data = [], []
+            expected_topics, topics = [], []
+            expected_data, data = [], []
             for pos, is_indexed in enumerate(event.indexed_list):
                 if is_indexed:
-                    topics_types.append(event.args[pos].typ)
+                    expected_topics.append(event.args[pos])
                     topics.append(self.stmt.args[pos])
                 else:
-                    data_types.append(event.args[pos].typ)
+                    expected_data.append(event.args[pos])
                     data.append(self.stmt.args[pos])
-            topics = pack_logging_topics(event.event_id, topics, topics_types, self.context)
-            inargs, inargsize, inarg_start = pack_logging_data(data_types, data, self.context)
+            topics = pack_logging_topics(event.event_id, topics, expected_topics, self.context)
+            inargs, inargsize, inarg_start = pack_logging_data(expected_data, data, self.context)
             return LLLnode.from_list(['seq', inargs, ["log" + str(len(topics)), inarg_start, inargsize] + topics], typ=None, pos=getpos(self.stmt))
         else:
             raise StructureException("Unsupported operator: %r" % ast.dump(self.stmt), self.stmt)


### PR DESCRIPTION
### - What I did
Add a check to make sure the number of logging arguments inputed match the number of  logging arguments declared.
Fixes #519 
Add support for data byte arrays of different sizes.
Fixes #520

### - How I did it
Added a conditional that checks to make sure a log is receiving the correct number of arguments.
Change the offset of `bytearray_to_num` to be the `maxlen` of a bytearray though this needs to be refined further (I'm thinking in a future PR) because the current bytes output padding is reversed (see below):
```
MyLog: __log({arg1: bytes <= 20})

def foo(_arg1: bytes <= 20):
    log.MyLog(_arg1)
```
```
c.foo('hello')
outputs => b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00hello'
should be => b'hello\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
```
### - How to verify it
Look at the tests I added
### - Description for the changelog
None
### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/17552858/33356735-807d3de0-d47b-11e7-9943-d3d1f55d2afd.png)

