### PR TITLE
Change @internal decorator to @private decorator.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,10 +48,11 @@ Following the principles and goals, Viper **does not** provide the following fea
 Compatibility-breaking Changelog
 ********************************
 
+* **2017.11.29**: ``@internal`` renamed to ``@private```.
 * **2017.11.15**: Functions require either ``@internal`` or ``@public`` decorators.
 * **2017.07.25**: The ``def foo() -> num(const): ...`` syntax no longer works; you now need to do ``def foo() -> num: ...`` with a ``@constant`` decorator on the previous line.
 * **2017.07.25**: Functions without a ``@payable`` decorator now fail when called with nonzero wei.
-* **2017.07.25**: A function can only call functions that are declared above it (that is, A can call B only if B appears earlier in the code than A does). This was introduced 
+* **2017.07.25**: A function can only call functions that are declared above it (that is, A can call B only if B appears earlier in the code than A does). This was introduced
   to prevent infinite looping through recursion.
 
 ********

--- a/docs/old_readme.txt
+++ b/docs/old_readme.txt
@@ -47,7 +47,7 @@ Note that not all programs that satisfy the following are valid; for example, th
     defs = <def> <def> ...
     def = <0 or more decorators> def <funname>(<argname>: <type>, <argname>: <type>...): <body>
         OR <0 or more decorators> def <funname>(<argname>: <type>, <argname>: <type>...) -> <type>: <body>
-    decorator = @constant OR @payable OR @internal
+    decorator = @constant OR @payable OR @private OR @public
     argname = <str>
     body = <stmt> <stmt> ...
     stmt = <varname> = <type>
@@ -151,14 +151,14 @@ deadline: timestamp
 goal: wei_value
 refundIndex: num
 timelimit: timedelta
-    
+
 # Setup global variables
 def __init__(_beneficiary: address, _goal: wei_value, _timelimit: timedelta):
     self.beneficiary = _beneficiary
     self.deadline = block.timestamp + _timelimit
     self.timelimit = _timelimit
     self.goal = _goal
-    
+
 # Participate in this crowdfunding campaign
 @payable
 def participate():
@@ -166,12 +166,12 @@ def participate():
     nfi = self.nextFunderIndex
     self.funders[nfi] = {sender: msg.sender, value: msg.value}
     self.nextFunderIndex = nfi + 1
-    
+
 # Enough money was raised! Send funds to the beneficiary
 def finalize():
     assert block.timestamp >= self.deadline and self.balance >= self.goal
     selfdestruct(self.beneficiary)
-    
+
 # Not enough money was raised! Refund everyone (max 30 people at a time
 # to avoid gas limit issues)
 def refund():
@@ -187,10 +187,10 @@ def refund():
 ```
 
 
-# Installation 
-Don't panic if installation fails, Viper is still under development and constant changes. Installation will be much simplified/optimized after a stable version release. 
+# Installation
+Don't panic if installation fails, Viper is still under development and constant changes. Installation will be much simplified/optimized after a stable version release.
 
-Take a deep breath and follow, please create an issue if any errors encountered. 
+Take a deep breath and follow, please create an issue if any errors encountered.
 
 It is **strongly recommended** to install in **a virtual Python environment (normally either `virtualenv` or `venv`)**, so that new packages installed and dependencies built are strictly contained in your viper project and will not alter/affect your other dev environment set-up.
 
@@ -200,7 +200,7 @@ To find out how to set-up virtual environment, check out: [virtualenv guide](htt
 - **Ubuntu (16.04 LTS)**
 1. Package update:
 ```
-sudo apt-get update 
+sudo apt-get update
 sudo apt-get -y upgrade
 ```
 
@@ -229,7 +229,7 @@ source viper/bin/activate
 ```
    To deactivate and return to default environment, (you should see the "(viper)" at the front disappeared.)
 ```
-deactivate 
+deactivate
 ```
 
    *Alternatively*: It is handy to use `pyenv` [https://github.com/pyenv/pyenv] to help manage your Python 3.6.2 or higher when Python releases new version. It works like a python version manager.
@@ -240,7 +240,7 @@ pyenv virtualenv viper
 5. Now, we are talking business, clone this Viper repo and install and test, and Walla!
 ```
 git clone https://github.com/ethereum/viper.git
-cd viper 
+cd viper
 python setup.py install
 python setup.py test
 ```
@@ -251,10 +251,10 @@ python setup.py test
 
 2. Make sure your python is 3.6 or higher. If not, you could checkout [python3 for MacOS guide](http://python-guide.readthedocs.io/en/latest/starting/install3/osx/)
 
-3. Now, go ahead and clone viper repo (not within `pyethereum` folder), and you run install and test, and Walla !! 
+3. Now, go ahead and clone viper repo (not within `pyethereum` folder), and you run install and test, and Walla !!
 ```
 git clone https://github.com/ethereum/viper.git
-cd viper 
+cd viper
 python setup.py install
 python setup.py test
 ```
@@ -264,7 +264,7 @@ If it fails with some error message on `openssl`, do the following:
 env LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include" pip install scrypt
 ```
 
-# Compile 
+# Compile
 To compile your file, use:
 ```
 viper yourFileName.v.py

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -41,7 +41,7 @@ Functions are the executable units of code within a contract.
 
 :ref:`function-calls` can happen internally or externally
 and have different levels of visibility (:ref:`visibility-and-getters`)
-towards other contracts. Functions must be decorated with either @public or @internal.
+towards other contracts. Functions must be decorated with either @public or @private.
 
 .. _structure-events:
 

--- a/tests/parser/features/decorators/test_private.py
+++ b/tests/parser/features/decorators/test_private.py
@@ -3,9 +3,9 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
     get_contract_with_gas_estimation, get_contract
 
 
-def test_internal_test():
-    internal_test = """
-@internal
+def test_private_test():
+    private_test_code = """
+@private
 def a() -> num:
     return 5
 
@@ -14,7 +14,7 @@ def returnten() -> num:
     return self.a() * 2
     """
 
-    c = get_contract_with_gas_estimation(internal_test)
+    c = get_contract_with_gas_estimation(private_test_code)
     assert c.returnten() == 10
 
-    print("Passed internal function test")
+    print("Passed private function test")

--- a/tests/parser/features/decorators/test_public.py
+++ b/tests/parser/features/decorators/test_public.py
@@ -8,7 +8,7 @@ from tests.setup_transaction_tests import chain as s, tester as t, ethereum_util
 def test_invalid_if_both_public_and_internal(assert_compile_failed):
     code = """
 @public
-@internal
+@private
 def foo():
     x = 1
 """
@@ -23,6 +23,3 @@ def foo():
 """
 
     assert_compile_failed(lambda: get_contract_with_gas_estimation(code), StructureException)
-
-
-

--- a/tests/parser/syntax/test_invalids.py
+++ b/tests/parser/syntax/test_invalids.py
@@ -160,7 +160,7 @@ def foo() -> num:
 
 must_succeed("""
 x: num
-@internal
+@private
 def foo() -> num:
     self.x = 5
 """)

--- a/viper/parser/parser.py
+++ b/viper/parser/parser.py
@@ -313,7 +313,7 @@ def mk_full_signature(code):
         o.append(sig.to_abi_dict())
     for code in _defs:
         sig = FunctionSignature.from_definition(code)
-        if not sig.internal:
+        if not sig.private:
             o.append(sig.to_abi_dict())
     return o
 
@@ -445,7 +445,7 @@ def parse_func(code, _globals, sigs, origcode, _vars=None):
     # Add asserts for payable and internal
     if not sig.payable:
         clampers.append(['assert', ['iszero', 'callvalue']])
-    if sig.internal:
+    if sig.private:
         clampers.append(['assert', ['eq', 'caller', 'address']])
     # Fill in variable positions
     for arg in sig.args:


### PR DESCRIPTION
### - What I did

Implements https://github.com/ethereum/viper/issues/471.

### - How I did it

Was quite simple, just renamed internal in function_signature.py to private, and then replaced all other occurrences.

### - How to verify it
Compile something like:
```python

@private
def _add(a: num, b: num) -> num:
    return a + b


@public
def add(a: num, b: num) -> num:
    self._add(a, b)

```
And check/ttest the abi and contract output.

### - Description for the changelog

### - Cute Animal Picture
![](https://vignette.wikia.nocookie.net/puppyinmypocketfanon/images/4/49/L-Baby-Fox.jpg/revision/latest?cb=20130421001806)
