### PR TITLE
 Check return type of lists match.

### DIFF
--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -109,6 +109,20 @@ b: num[5]
 def foo():
     x = self.b[0].cow
     """,
+    """
+@public
+def foo()->bool[2]:
+    a: decimal[2]
+    a[0] = 1
+    return a
+    """,
+    """
+@public
+def foo()->bool[2]:
+    a: bool[1000]
+    a[0] = 1
+    return a
+    """
 ]
 
 

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -1,4 +1,5 @@
 import ast
+import re
 
 from viper.exceptions import (
     ConstancyViolationException,
@@ -350,6 +351,15 @@ class Stmt(object):
                 raise Exception("Invalid location: %s" % sub.location)
 
         elif isinstance(sub.typ, ListType):
+            sub_base_type = re.split(r'\(|\[', str(sub.typ.subtype))[0]
+            ret_base_type = re.split(r'\(|\[', str(self.context.return_type.subtype))[0]
+            if sub_base_type != ret_base_type and sub.value != 'multi':
+                raise TypeMismatchException(
+                    "List return type %r does not match specified return type, expecting %r" % (
+                        sub_base_type, ret_base_type
+                    ),
+                    self.stmt
+                )
             if sub.location == "memory" and sub.value != "multi":
                 return LLLnode.from_list(['return', sub, get_size_of_type(self.context.return_type) * 32],
                                             typ=None, pos=getpos(self.stmt))


### PR DESCRIPTION
### - What I did

Adds Fix #531.

### - How I did it

Was a bit trickier to detect the subtypes, I opted using split() because it interprets nested lists as well, without having to chain down to subtype.typ.subtype scenario, using `re` was actually the cleaner option! :smile:  

### - How to verify it

Check the issue #531, basically return a list of a different type.

### - Description for the changelog

N/A

### - Cute Animal Picture

![](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-8.jpg)
