### PR TITLE
Clamping decimal literals correctly.

### DIFF
--- a/tests/parser/exceptions/test_invalid_literal_exception.py
+++ b/tests/parser/exceptions/test_invalid_literal_exception.py
@@ -91,6 +91,14 @@ def foo():
 @public
 def foo():
     x = as_num256(3.1415)
+    """,
+    """
+# Test decimal limit.
+a:decimal
+
+@public
+def foo():
+    self.a = 170141183460469231731687303715884105727.888
     """
 ]
 

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -84,7 +84,7 @@ class Expr(object):
             return LLLnode.from_list(self.expr.n, typ=BaseType('num', None), pos=getpos(self.expr))
         elif isinstance(self.expr.n, float):
             numstring, num, den = get_number_as_fraction(self.expr, self.context)
-            if not (-2**127 * den < num < 2**127 * den):
+            if not (SizeLimits.MINNUM * den < num < SizeLimits.MAXNUM * den):
                 raise InvalidLiteralException("Number out of range: " + numstring, self.expr)
             if DECIMAL_DIVISOR % den:
                 raise InvalidLiteralException("Too many decimal places: " + numstring, self.expr)


### PR DESCRIPTION
### - What I did

Fix for #504 clamping of decimal literal.

### - How I did it
Just used suggested limit of den * MAXNUM/MINNUM & added test.

### - How to verify it
Check test.

### - Description for the changelog

### - Cute Animal Picture

![](http://www.cutestpaw.com/wp-content/uploads/2015/05/My-cute-bunny-you.jpg)