### PR TITLE
Create contract data type

### DIFF
--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -463,7 +463,13 @@ class Expr(object):
             return external_contract_call_expr(self.expr, self.context, contract_name, contract_address)
         elif isinstance(self.expr.func.value, ast.Attribute) and self.expr.func.value.attr in self.context.sigs:
             contract_name = self.expr.func.value.attr
-            contract_address = Expr.parse_value_expr(ast.parse('self.token_address').body[0].value, self.context)
+            var = self.context.globals[self.expr.func.value.attr]
+            contract_address = unwrap_location(LLLnode.from_list(var.pos, typ=var.typ, location='storage', pos=getpos(self.expr), annotation='self.' + self.expr.func.value.attr))
+            return external_contract_call_expr(self.expr, self.context, contract_name, contract_address)
+        elif isinstance(self.expr.func.value, ast.Attribute) and self.expr.func.value.attr in self.context.globals:
+            contract_name = self.context.globals[self.expr.func.value.attr].typ.unit
+            var = self.context.globals[self.expr.func.value.attr]
+            contract_address = unwrap_location(LLLnode.from_list(var.pos, typ=var.typ, location='storage', pos=getpos(self.expr), annotation='self.' + self.expr.func.value.attr))
             return external_contract_call_expr(self.expr, self.context, contract_name, contract_address)
         else:
             raise StructureException("Unsupported operator: %r" % ast.dump(self.expr), self.expr)

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -129,7 +129,14 @@ class Stmt(object):
             return external_contract_call_stmt(self.stmt, self.context, contract_name, contract_address)
         elif isinstance(self.stmt.func.value, ast.Attribute) and self.stmt.func.value.attr in self.context.sigs:
             contract_name = self.stmt.func.value.attr
-            contract_address = Expr.parse_value_expr(ast.parse('self.token_address').body[0].value, self.context)
+            var = self.context.globals[self.stmt.func.value.attr]
+            contract_address = unwrap_location(LLLnode.from_list(var.pos, typ=var.typ, location='storage', pos=getpos(self.stmt), annotation='self.' + self.stmt.func.value.attr))
+            return external_contract_call_stmt(self.stmt, self.context, contract_name, contract_address)
+        elif isinstance(self.stmt.func.value, ast.Attribute) and self.stmt.func.value.attr in self.context.globals:
+            contract_name = self.context.globals[self.stmt.func.value.attr].typ.unit
+            var = self.context.globals[self.stmt.func.value.attr]
+            contract_address = unwrap_location(LLLnode.from_list(var.pos, typ=var.typ, location='storage', pos=getpos(self.stmt), annotation='self.' + self.stmt.func.value.attr))
+            # import pdb; pdb.set_trace()
             return external_contract_call_stmt(self.stmt, self.context, contract_name, contract_address)
         elif isinstance(self.stmt.func, ast.Attribute) and self.stmt.func.value.id == 'log':
             if self.stmt.func.attr not in self.context.sigs['self']:

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -136,7 +136,6 @@ class Stmt(object):
             contract_name = self.context.globals[self.stmt.func.value.attr].typ.unit
             var = self.context.globals[self.stmt.func.value.attr]
             contract_address = unwrap_location(LLLnode.from_list(var.pos, typ=var.typ, location='storage', pos=getpos(self.stmt), annotation='self.' + self.stmt.func.value.attr))
-            # import pdb; pdb.set_trace()
             return external_contract_call_stmt(self.stmt, self.context, contract_name, contract_address)
         elif isinstance(self.stmt.func, ast.Attribute) and self.stmt.func.value.id == 'log':
             if self.stmt.func.attr not in self.context.sigs['self']:


### PR DESCRIPTION
### - What I did
Make it possible to declare contracts as discussed on the bimonthly Viper call:
The following syntax can now be used to make external contract calls:
```
    contract_1 = """
@public
def bar() -> num:
    return 1
"""

    contract_2 = """
class Bar():
    def bar() -> num: pass

bar_contract: Bar

@public
def foo(contract_address: contract(Bar)) -> num:
    self.bar_contract = contract_address
    return self.bar_contract.bar()
    """

    c1 = get_contract(contract_1)
    c2 = get_contract(contract_2)
    assert c2.foo(c1.address) == 1
```
### - How I did it
 1) Allow for external contracts to be used when declaring variables
 2) Create a special contract data type that can be used to save the address of an external contract
### - How to verify it
Look at the tests I added and make sure that I didn't break any existing functionality
### - Description for the changelog
Add contract data type
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/33521234-b26f2ee2-d789-11e7-99da-83465840ea3a.png)

