### PR TITLE
Fix exponents with units

### DIFF
--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -285,6 +285,8 @@ class Expr(object):
         elif isinstance(self.expr.op, ast.Pow):
             if left.typ.positional or right.typ.positional:
                 raise TypeMismatchException("Cannot use positional values as exponential arguments!", self.expr)
+            if right.typ.unit:
+                raise TypeMismatchException("Cannot use unit values as exponents", self.expr)
             new_unit = combine_units(left.typ.unit, right.typ.unit)
             if ltyp == rtyp == 'num':
                 o = LLLnode.from_list(['exp', left, right], typ=BaseType('num', new_unit), pos=getpos(self.expr))


### PR DESCRIPTION
### - What I did
Fix incorrect exponents when dealing with units so that now the following is invalid:
```
+def foo():
    a: num(wei)
    b: num(wei)
    c = a ** b
```
Fixes #530 
### - How I did it
Created a test that shouldn't work and made it invalid.
### - How to verify it
Look at the tests I added in `test_num.py`
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/33528037-2a0896e4-d818-11e7-8104-8c3aa1a607a6.png)

