### PR TITLE
Update version of ethereum

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license=license,
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=[
-        'ethereum==2.1.0',
+        'ethereum==2.1.3',
         'bumpversion',
         'pytest-cov',
         'pytest-runner', # Must be after pytest-cov or it will not work


### PR DESCRIPTION
### - What I did

Updated the version of `ethereum` to 2.1.3. `make init` fails right now because `setuptools` v38 doesn't like `sets` or `dicts` anymore. See this commit in pyethereum for the fix there: https://github.com/ethereum/pyethereum/commit/6b6f9a8e27dc3c2a4fb3ba095a8c96849e22c0a0

The error I get while installing the current master is as follows:

```
Collecting ethereum==2.1.0 (from -r requirements.txt (line 1))
  Downloading ethereum-2.1.0.tar.gz (156kB)
    100% |████████████████████████████████| 163kB 2.8MB/s
    Complete output from command python setup.py egg_info:
    error in ethereum setup command: 'tests_require' must be a string or list of strings containing valid project/version requirement specifiers; Unordered types are not allowed
```

### - How I did it

Updated install_requires in setup.py.

### - How to verify it

Attempt the installation on a dev machine with `setuptools` > v38. `make test` should pass.

### - Description for the changelog

Updated ethereum dependency.

### - Cute Animal Picture

![image](https://user-images.githubusercontent.com/67953/33590132-459cc4aa-d932-11e7-9322-3f64e77fce2b.png)