### PR TITLE
Internal contract call gas estimates

### DIFF
--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -130,7 +130,7 @@ def returnten() -> num:
         self.increment()
     return self.counter
     """
-    c = get_contract(selfcall_code_5)
+    c = get_contract_with_gas_estimation(selfcall_code_5)
     assert c.returnten() == 10
 
     print("Passed self-call statement test")
@@ -158,7 +158,7 @@ def return_mongoose_revolution_32_excls() -> bytes <= 201:
     return self.hardtest("megamongoose123", 4, 8, concat("russian revolution", self.excls), 8, 42)
     """
 
-    c = get_contract(selfcall_code_6)
+    c = get_contract_with_gas_estimation(selfcall_code_6)
     assert c.return_mongoose_revolution_32_excls() == b"mongoose_revolution" + b"!" * 32
 
     print("Passed composite self-call test")

--- a/tests/parser/features/test_internal_call.py
+++ b/tests/parser/features/test_internal_call.py
@@ -39,7 +39,7 @@ def return_hash_of_rzpadded_cow() -> bytes32:
     return self._hashy(0x636f770000000000000000000000000000000000000000000000000000000000)
     """
 
-    c = get_contract(selfcall_code_2)
+    c = get_contract_with_gas_estimation(selfcall_code_2)
     assert c.returnten() == 10
     assert c.return_hash_of_rzpadded_cow() == u.sha3(b'cow' + b'\x00' * 29)
 
@@ -107,7 +107,7 @@ def return_goose2() -> bytes <= 10:
     return self.slicey2(5, "goosedog")
     """
 
-    c = get_contract(selfcall_code_4)
+    c = get_contract_with_gas_estimation(selfcall_code_4)
     assert c.returnten() == 10
     assert c.return_mongoose() == b"mongoose"
     assert c.return_goose() == b"goose"

--- a/viper/functions.py
+++ b/viper/functions.py
@@ -289,7 +289,7 @@ def concat(expr, context):
     # Memory location of the output
     seq.append(placeholder)
     return LLLnode.from_list(
-        ['with', '_poz', 0, ['seq'] + seq], typ=ByteArrayType(total_maxlen), location='memory', pos=getpos(expr)
+        ['with', '_poz', 0, ['seq'] + seq], typ=ByteArrayType(total_maxlen), location='memory', pos=getpos(expr), annotation='concat'
     )
 
 

--- a/viper/optimizer.py
+++ b/viper/optimizer.py
@@ -106,9 +106,9 @@ def optimize(node):
                 o.append(arg)
         return LLLnode(node.value, o, node.typ, node.location, node.pos, node.annotation, add_gas_estimate=node.add_gas_estimate)
     elif hasattr(node, 'total_gas'):
-        o = LLLnode(node.value, argz, node.typ, node.location, node.pos, node.annotation)
+        o = LLLnode(node.value, argz, node.typ, node.location, node.pos, node.annotation, add_gas_estimate=node.add_gas_estimate)
         o.total_gas = node.total_gas - node.gas + o.gas
         o.func_name = node.func_name
         return o
     else:
-        return LLLnode(node.value, argz, node.typ, node.location, node.pos, node.annotation)
+        return LLLnode(node.value, argz, node.typ, node.location, node.pos, node.annotation, add_gas_estimate=node.add_gas_estimate)

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -457,7 +457,8 @@ class Expr(object):
                                         ['assert', ['call', ['gas'], ['address'], 0,
                                                         inargs, inargsize,
                                                         output_placeholder, get_size_of_type(sig.output_type) * 32]],
-                                        returner], typ=sig.output_type, location='memory', pos=getpos(self.expr), add_gas_estimate=add_gas)
+                                        returner], typ=sig.output_type, location='memory',
+                                        pos=getpos(self.expr), add_gas_estimate=add_gas, annotation='Internal Call: %s' % method_name)
             o.gas += sig.gas
             return o
         elif isinstance(self.expr.func, ast.Attribute) and isinstance(self.expr.func.value, ast.Call):

--- a/viper/parser/expr.py
+++ b/viper/parser/expr.py
@@ -444,6 +444,7 @@ class Expr(object):
                 raise VariableDeclarationException("Function not declared yet (reminder: functions cannot "
                                                    "call functions later in code than themselves): %s" % self.expr.func.attr)
             sig = self.context.sigs['self'][self.expr.func.attr]
+            add_gas = self.context.sigs['self'][method_name].gas  # gas of call
             inargs, inargsize = pack_arguments(sig, [Expr(arg, self.context).lll_node for arg in self.expr.args], self.context)
             output_placeholder = self.context.new_placeholder(typ=sig.output_type)
             if isinstance(sig.output_type, BaseType):
@@ -456,7 +457,7 @@ class Expr(object):
                                         ['assert', ['call', ['gas'], ['address'], 0,
                                                         inargs, inargsize,
                                                         output_placeholder, get_size_of_type(sig.output_type) * 32]],
-                                        returner], typ=sig.output_type, location='memory', pos=getpos(self.expr))
+                                        returner], typ=sig.output_type, location='memory', pos=getpos(self.expr), add_gas_estimate=add_gas)
             o.gas += sig.gas
             return o
         elif isinstance(self.expr.func, ast.Attribute) and isinstance(self.expr.func.value, ast.Call):


### PR DESCRIPTION
### - What I did

- Improve internal contract call gas estimates.
- Added annotations so the LLL repr is easier to read.

### - How I did it

Found places in expr.py & stmt.py were internal calls are handed, then looked up the gas of those calls.

### - How to verify it

Check tests ;)

### - Description for the changelog

### - Cute Animal Picture

![](http://www.animal-space.net/wp-content/uploads/2012/05/cute-babay-panda-451.jpg)