### PR TITLE
Add length check to event topics

### DIFF
--- a/tests/parser/features/test_logging.py
+++ b/tests/parser/features/test_logging.py
@@ -640,3 +640,21 @@ def set_list():
     c.set_list()
     c.foo()
     assert get_last_log(t, c)["_value"] == [1.33, 2.33, 3.33, 4.33]
+
+
+def test_logging_fails_when_declartation_is_too_big(assert_tx_failed, get_contract_with_gas_estimation):
+    code = """
+Bar: __log__({_value: indexed(bytes <= 33)})
+"""
+    assert_tx_failed(lambda: get_contract_with_gas_estimation(code), VariableDeclarationException)
+
+
+def test_logging_fails_when_input_is_too_big(assert_tx_failed, get_contract_with_gas_estimation):
+    code = """
+Bar: __log__({_value: indexed(bytes <= 32)})
+
+@public
+def foo(inp: bytes <= 33):
+    log.Bar(inp)
+"""
+    assert_tx_failed(lambda: get_contract_with_gas_estimation(code), TypeMismatchException)

--- a/viper/signatures/event_signature.py
+++ b/viper/signatures/event_signature.py
@@ -39,9 +39,9 @@ class EventSignature():
                     else:
                         raise VariableDeclarationException("Only indexed keyword is allowed", arg)
                 else:
-                    if hasattr(typ, 'left') and typ.left.id == 'bytes' and typ.comparators[0].n > 32:
-                        raise VariableDeclarationException("Can only log a maximum of 32 bytes at a time.")
                     indexed_list.append(False)
+                if hasattr(typ, 'left') and typ.left.id == 'bytes' and typ.comparators[0].n > 32:
+                    raise VariableDeclarationException("Can only log a maximum of 32 bytes at a time.")
                 if topics_count > 4:
                     raise VariableDeclarationException("Maximum of 3 topics {} given".format(topics_count - 1), arg)
                 if not isinstance(arg, str):


### PR DESCRIPTION
### - What I did
Added length checking to event topics
Fixes #546 
### - How I did it
Moved the length check outside of a conditional in `event_signature.py` so it's never skipped
### - How to verify it
Look at the tests I added
### - Description for the changelog
None
### - Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/33746069-f8e46394-dbba-11e7-8af0-e4064afdd41e.png)

