### PR TITLE
Split comments over two lines and minor edits: safe remote purchases

### DIFF
--- a/docs/viper-by-example.rst
+++ b/docs/viper-by-example.rst
@@ -164,7 +164,7 @@ logic. Let's break down this contract bit by bit.
 
 .. literalinclude:: ../examples/safe_remote_purchase/safe_remote_purchase.v.py
   :language: python
-  :lines: 10-13
+  :lines: 16-19
 
 Like the other contracts, we begin by declaring our global variables public with
 their respective datatypes. Remember that the ``public`` function allows the
@@ -172,7 +172,7 @@ variables to be *readable* by an external caller, but not *writeable*.
 
 .. literalinclude:: ../examples/safe_remote_purchase/safe_remote_purchase.v.py
   :language: python
-  :lines: 18-23
+  :lines: 24-31
 
 With a ``@payable`` decorator on the constructor, the contract creator will be
 required to make an initial deposit equal to twice the item's ``value`` to
@@ -186,10 +186,10 @@ in the contract variable ``self.value`` and saves the contract creator into
 
 .. literalinclude:: ../examples/safe_remote_purchase/safe_remote_purchase.v.py
   :language: python
-  :lines: 25-28
+  :lines: 33-38
 
 The ``abort()`` method is a method only callable by the seller and while the
-contract is still ``unlocked`` - meaning it is callable only prior to any buyer
+contract is still ``unlocked``—meaning it is callable only prior to any buyer
 making a purchase. As we will see in the ``purchase()`` method that when
 a buyer calls the ``purchase()`` method and sends a valid amount to the contract,
 the contract will be locked and the seller will no longer be able to call
@@ -201,23 +201,23 @@ subsequently destroys the contract.
 
 .. literalinclude:: ../examples/safe_remote_purchase/safe_remote_purchase.v.py
   :language: python
-  :lines: 30-35
+  :lines: 40-46
 
 Like the constructor, the ``purchase()`` method has a ``@payable`` decorator,
 meaning it can be called with a payment. For the buyer to make a valid
-purchase, we must first ``assert`` that the contract's unlocked property is
-``False`` and that the amount sent is equal to twice the item's value. We then
+purchase, we must first ``assert`` that the contract's ``unlocked`` property is
+``True`` and that the amount sent is equal to twice the item's value. We then
 set the buyer to the ``msg.sender`` and lock the contract. At this point, the
 contract has a balance equal to 4 times the item value and the seller must
 send the item to the buyer.
 
 .. literalinclude:: ../examples/safe_remote_purchase/safe_remote_purchase.v.py
   :language: python
-  :lines: 37-41
+  :lines: 48-55
 
 Finally, upon the buyer's receipt of the item, the buyer can confirm their
 receipt by calling the ``received()`` method to distribute the funds as
-intended - the seller receives 3/4 of the contract balance and the buyer
+intended—where the seller receives 3/4 of the contract balance and the buyer
 receives 1/4.
 
 By calling ``received()``, we begin by checking that the contract is indeed

--- a/examples/safe_remote_purchase/safe_remote_purchase.v.py
+++ b/examples/safe_remote_purchase/safe_remote_purchase.v.py
@@ -1,11 +1,17 @@
-#Safe Remote Purchase (https://github.com/ethereum/solidity/blob/develop/docs/solidity-by-example.rst) ported to viper and optimized
+#Safe Remote Purchase 
+#Originally from
+#https://github.com/ethereum/solidity/blob/develop/docs/solidity-by-example.rst 
+#ported to viper and optimized
 
 #Rundown of the transaction:
-#1. Seller posts item for sale and posts safety deposit of double the item value. Balance is 2*value.
+#1. Seller posts item for sale and posts safety deposit of double the item value.
+# Balance is 2*value.
 #(1.1. Seller can reclaim deposit and close the sale as long as nothing was purchased.)
-#2. Buyer purchases item (value) plus posts an additional safety deposit (Item value). Balance is 4*value
-#3. Seller ships item
-#4. Buyer confirms receiving the item. Buyer's deposit (value) is returned. Seller's deposit (2*value) + items value is returned. Balance is 0.
+#2. Buyer purchases item (value) plus posts an additional safety deposit (Item value).
+# Balance is 4*value.
+#3. Seller ships item.
+#4. Buyer confirms receiving the item. Buyer's deposit (value) is returned. 
+#Seller's deposit (2*value) + items value is returned. Balance is 0.
 
 value: public(wei_value) #Value of the item
 seller: public(address)
@@ -14,32 +20,36 @@ unlocked: public(bool)
 #@constant
 #def unlocked() -> bool: #Is a refund possible for the seller?
 #    return (self.balance == self.value*2)
-#    
+    
 @public
 @payable
 def __init__():
     assert (msg.value % 2) == 0
-    self.value = msg.value / 2 #Seller initializes contract by posting a safety deposit of 2*value of the item up for sale
+    self.value = msg.value / 2 #The seller initializes the contract by  
+        #posting a safety deposit of 2*value of the item up for sale.
     self.seller = msg.sender
     self.unlocked = true
 
 @public
 def abort():
-    assert self.unlocked #Is the contract still refundable
-    assert msg.sender == self.seller #Only seller can refund his deposit before any buyer purchases the item
-    selfdestruct(self.seller) #Refunds seller, deletes contract
+    assert self.unlocked #Is the contract still refundable?
+    assert msg.sender == self.seller #Only the seller can refund 
+        # his deposit before any buyer purchases the item.
+    selfdestruct(self.seller) #Refunds the seller and deletes the contract.
 
 @public
 @payable
 def purchase():
-    assert self.unlocked #Contract still open (item still up for sale)?
-    assert msg.value == (2*self.value) #Is the deposit of correct value?
+    assert self.unlocked #Is the contract still open (is the item still up for sale)?
+    assert msg.value == (2*self.value) #Is the deposit the correct value?
     self.buyer = msg.sender
     self.unlocked = false
 
 @public
 def received():
-    assert not self.unlocked #Is the item already purchased and pending confirmation of buyer
+    assert not self.unlocked #Is the item already purchased and pending confirmation
+        # from the buyer?
     assert msg.sender == self.buyer 
-    send(self.buyer, self.value) #Return deposit (=value) to buyer
-    selfdestruct(self.seller) #Returns deposit (=2*value) and the purchase price (=value)
+    send(self.buyer, self.value) #Return the buyer's deposit (=value) to the buyer.
+    selfdestruct(self.seller) #Return the seller's deposit (=2*value)
+        # and the purchase price (=value) to the seller.


### PR DESCRIPTION
Split comments over two lines where necessary to fit on the page on readthedocs in the safe remote purchases example Python code. Update Safe Remote Purchases doc: line numbers, minor edits.
![screenshot from 2017-12-09 17-20-03](https://user-images.githubusercontent.com/16969914/33793116-3d140128-dd05-11e7-9f38-8346d030009d.png)