### PR TITLE
virtualenv -p /usr/local/lib/python3.6/bin/python3 > virtualenv -p python3.6

### DIFF
--- a/docs/installing-viper.rst
+++ b/docs/installing-viper.rst
@@ -75,7 +75,7 @@ other development environment set-up.
 
 To create a new virtual environment for Viper run the following commands:
 ::
-    virtualenv -p /usr/local/lib/python3.6/bin/python3 --no-site-packages ~/viper-venv
+    virtualenv -p python3.6 --no-site-packages ~/viper-venv
     source ~/viper-venv/bin/activate
 
 To find out more about virtual environments, check out:


### PR DESCRIPTION
For setting up a virtual environment command, I modified the interpreter to python3.6 instead of the path to python3.6, which in my case the former did work while the latter didn't.

Related: https://github.com/ethereum/viper/issues/558

![screenshot from 2017-12-12 09-53-00](https://user-images.githubusercontent.com/16969914/33858013-464d07d4-df22-11e7-87ca-2b6a344d703d.png)
