### PR TITLE
Add a note on how to fix `fatal error: openssl/aes.h: No such file or directory` in the `make` output

### DIFF
--- a/docs/installing-viper.rst
+++ b/docs/installing-viper.rst
@@ -103,7 +103,9 @@ If everything works correctly, you are now able to compile your own smart contra
 However, please keep in mind that Viper is still experimental and not ready for production!
 
 .. note::
-    For MacOS users:
+    If you get the error `fatal error: openssl/aes.h: No such file or directory` in the output of `make`, then run `sudo apt-get install libssl-dev1`, then run `make` again.
+
+    **For MacOS users:**
 
     Apple has deprecated use of OpenSSL in favor of its own TLS and crypto
     libraries. This means that you will need to export some OpenSSL settings


### PR DESCRIPTION
Related:
https://github.com/ethereum/viper/issues/573

### - Cute Animal Picture
![screenshot from 2017-12-12 11-29-48](https://user-images.githubusercontent.com/16969914/33861047-cbfbebe0-df2f-11e7-9e5a-9cf3b026b108.png)
