### PR TITLE
Check for missing return statement

### DIFF
--- a/tests/parser/exceptions/test_invalid_payable.py
+++ b/tests/parser/exceptions/test_invalid_payable.py
@@ -27,6 +27,7 @@ x: num
 @payable
 def foo() -> num:
     self.x = 5
+    return self.x
     """,
     """
 @public

--- a/tests/parser/features/external_contracts/test_external_contract_calls.py
+++ b/tests/parser/features/external_contracts/test_external_contract_calls.py
@@ -495,7 +495,7 @@ class Bar():
 bar_contract: public(Bar)
 
 @public
-def foo(contract_address: contract(Bar)) -> num:
+def foo(contract_address: contract(Bar)):
     self.bar_contract = contract_address
 
 @public

--- a/tests/parser/syntax/test_invalids.py
+++ b/tests/parser/syntax/test_invalids.py
@@ -154,14 +154,14 @@ def foo():
 must_succeed("""
 x: num
 @public
-def foo() -> num:
+def foo():
     self.x = 5
 """)
 
 must_succeed("""
 x: num
 @private
-def foo() -> num:
+def foo():
     self.x = 5
 """)
 

--- a/tests/parser/syntax/test_list.py
+++ b/tests/parser/syntax/test_list.py
@@ -32,21 +32,21 @@ def foo() -> num[2]:
 y: num[3]
 
 @public
-def foo(x: num[3]) -> num:
+def foo(x: num[3]):
     self.y = x[0]
     """,
     """
 y: num[3]
 
 @public
-def foo(x: num[3]) -> num:
+def foo(x: num[3]):
     self.y[0] = x
     """,
     """
 y: num[4]
 
 @public
-def foo(x: num[3]) -> num:
+def foo(x: num[3]):
     self.y = x
     """,
     """
@@ -168,28 +168,28 @@ def foo(x: num[3]) -> num:
 y: num[3]
 
 @public
-def foo(x: num[3]) -> num:
+def foo(x: num[3]):
     self.y = x
     """,
     """
 y: decimal[3]
 
 @public
-def foo(x: num[3]) -> num:
+def foo(x: num[3]):
     self.y = x
     """,
     """
 y: decimal[2][2]
 
 @public
-def foo(x: num[2][2]) -> num:
+def foo(x: num[2][2]):
     self.y = x
     """,
     """
 y: decimal[2]
 
 @public
-def foo(x: num[2][2]) -> num:
+def foo(x: num[2][2]):
     self.y = x[1]
     """,
     """

--- a/tests/parser/syntax/test_missing_return.py
+++ b/tests/parser/syntax/test_missing_return.py
@@ -18,3 +18,23 @@ def foo() -> num:
 def test_missing_return(bad_code):
     with raises(StructureException):
         compiler.compile(bad_code)
+
+
+
+valid_list = [
+    """
+@public
+def foo() -> num:
+    return 123
+    """,
+    """
+@public
+def foo() -> num:
+    if false:
+        return 123
+    """,  # For the time being this is valid code, even though it should not be.
+]
+
+@pytest.mark.parametrize('good_code', valid_list)
+def test_return_success(good_code):
+    assert compiler.compile(good_code) is not None

--- a/tests/parser/syntax/test_missing_return.py
+++ b/tests/parser/syntax/test_missing_return.py
@@ -1,0 +1,20 @@
+import pytest
+from pytest import raises
+
+from viper import compiler
+from viper.exceptions import StructureException
+
+
+fail_list = [
+	"""
+@public
+def foo() -> num:
+	pass
+	""",
+]
+
+
+@pytest.mark.parametrize('bad_code', fail_list)
+def test_missing_return(bad_code):
+    with raises(StructureException):
+        compiler.compile(bad_code)

--- a/viper/parser/stmt.py
+++ b/viper/parser/stmt.py
@@ -320,6 +320,7 @@ class Stmt(object):
         if not self.stmt.value:
             raise TypeMismatchException("Expecting to return a value", self.stmt)
         sub = Expr(self.stmt.value, self.context).lll_node
+        self.context.increment_return_counter()
         # Returning a value (most common case)
         if isinstance(sub.typ, BaseType):
             if not isinstance(self.context.return_type, BaseType):


### PR DESCRIPTION
### - What I did

Partial fix for #590.
Check for a minimum of 1 return statement if specified.

### - How I did it
Added a count in the function context.

### - How to verify it
```python
@public
def foo() -> num:
        pass
```
### - Description for the changelog

### - Cute Animal Picture
![](https://i.pinimg.com/736x/40/11/3b/40113b9f960c8d37abfbd836b0ac95b2--cute-pugs-puppies-adorable-pugs.jpg)