### PR TITLE
Update dockerfile to use slim image base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,27 @@
-FROM python:3.6
+FROM python:3.6-slim
 
-MAINTAINER Obul <obulpathi@merkletree.vc>
+# Specify label-schema specific arguments and labels.
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.name="viper" \
+    org.label-schema.description="Viper is an experimental programming language" \
+    org.label-schema.url="https://viper.readthedocs.io/en/latest/" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/ethereum/viper" \
+    org.label-schema.vendor="Ethereum" \
+    org.label-schema.schema-version="1.0"
 
 # coincurve requires libgmp
 RUN apt-get update && \
-    apt-get install -y libgmp-dev
+    apt-get install -y --no-install-recommends apt-utils gcc libc6-dev libc-dev libssl-dev libgmp-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD . /code
 
 # download and install Viper
+# WORKDIR /code
+# RUN git clone https://github.com/ethereum/viper.git
 WORKDIR /code
-RUN git clone https://github.com/ethereum/viper.git
-WORKDIR /code/viper
-RUN python setup.py install
+RUN python setup.py install && \
+    apt-get purge -y --auto-remove apt-utils gcc libc6-dev libc-dev libssl-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,6 @@ RUN apt-get update && \
 
 ADD . /code
 
-# download and install Viper
-# WORKDIR /code
-# RUN git clone https://github.com/ethereum/viper.git
 WORKDIR /code
 RUN python setup.py install && \
     apt-get purge -y --auto-remove apt-utils gcc libc6-dev libc-dev libssl-dev

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,8 @@ docs:
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	open docs/_build/html/index.html
+
+docker-build:
+	@docker build \
+		--build-arg VCS_REF=`git rev-parse --short HEAD` \
+		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` .

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ docs:
 	open docs/_build/html/index.html
 
 docker-build:
-	@docker build \
+	@docker build -t viper \
 		--build-arg VCS_REF=`git rev-parse --short HEAD` \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` .


### PR DESCRIPTION
### - What I did
Modified the Dockerfile to use http://label-schema.org/rc1/ syntax to label the docker image and switched the base image to use the latest slim 3.6 base image.
This decreases the docker image size from `740MB` to `278MB` without any usage/compatibility changes.

### - How I did it

- Removed deprecated `MAINTAINER` directive.
- Added new `LABEL` directives adhering to `label schema` specific to the repository.
- Modified the base image from `python:3.6` to `python:3.6-slim`
- Modified installed dependencies to install only whats necessary and purge them following build of package.
- Switch from cloning the github repository to using the existing repository, since we're already in the repo.

### - How to verify it
- Run `make docker-build`

### - Description for the changelog
- Switch Dockerfile to `python:3.6-slim` from `python:3.6` to decrease size from `740MB` to `278MB`.

### - Cute Animal Picture
![Viper](https://www.stlzoo.org/files/cache/538538d141e211cf6ba5b01584db6538.jpg)
